### PR TITLE
Add initialization and demo data helpers

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,1758 @@
+const SPREADSHEET_ID = 'PUT_YOUR_SHEET_ID_HERE'; // required
+
+const SHEET_DEFINITIONS = {
+  Users: {
+    headers: [
+      'id',
+      'firstName',
+      'lastName',
+      'email',
+      'passwordHash',
+      'role',
+      'parentUserId',
+      'notificationEmail',
+      'tutorialSeen',
+      'isActive',
+      'createdAt',
+      'updatedAt'
+    ]
+  },
+  Tasks: {
+    headers: [
+      'id',
+      'title',
+      'description',
+      'assignedTo',
+      'priority',
+      'status',
+      'dueDate',
+      'estimatedHours',
+      'tags',
+      'links',
+      'createdBy',
+      'createdAt',
+      'updatedAt',
+      'totalSeconds'
+    ]
+  },
+  TimeLog: {
+    headers: [
+      'id',
+      'taskId',
+      'userEmail',
+      'startedAt',
+      'stoppedAt',
+      'durationSeconds'
+    ]
+  },
+  Tools: {
+    headers: [
+      'id',
+      'iconUrl',
+      'name',
+      'toolUrl',
+      'isActive',
+      'createdAt',
+      'updatedAt',
+      'sortOrder'
+    ]
+  }
+};
+
+const PRIORITIES = ['Low', 'Normal', 'High'];
+const STATUSES = ['Todo', 'Doing', 'Done', 'Blocked'];
+const ROLE_ORDER = ['MASTER_ADMIN', 'ADMIN', 'MANAGER', 'USER'];
+const BRAND_LOGO_URL = 'https://images.emojiterra.com/google/noto-emoji/unicode-16.0/color/svg/1f300.svg';
+
+function doGet(e) {
+  if (e && e.parameter && e.parameter.action === 'exportTasks') {
+    const params = {
+      view: e.parameter.view,
+      q: e.parameter.q,
+      includeDone: e.parameter.includeDone === 'true',
+      statusFilters: e.parameter.status ? e.parameter.status.split(',') : [],
+      overdueOnly: e.parameter.overdue === 'true'
+    };
+    return exportTasksCSV(params);
+  }
+  return HtmlService.createHtmlOutputFromFile('index')
+    .setTitle('AuraFlow');
+}
+
+function getEnv_() {
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  const data = {
+    spreadsheetId: SPREADSHEET_ID,
+    users: { sheet: 'Users', headers: SHEET_DEFINITIONS.Users.headers },
+    tasks: { sheet: 'Tasks', headers: SHEET_DEFINITIONS.Tasks.headers },
+    timeLog: { sheet: 'TimeLog', headers: SHEET_DEFINITIONS.TimeLog.headers },
+    tools: { sheet: 'Tools', headers: SHEET_DEFINITIONS.Tools.headers },
+    appUrl: getAppUrl_()
+  };
+  return { success: true, data: data };
+}
+
+function ensureSpreadsheet_() {
+  if (!SPREADSHEET_ID || SPREADSHEET_ID === 'PUT_YOUR_SHEET_ID_HERE') {
+    return { success: false, message: 'INVALID_SPREADSHEET_ID' };
+  }
+  try {
+    const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+    const sheets = {};
+    Object.keys(SHEET_DEFINITIONS).forEach(function (name) {
+      const headers = SHEET_DEFINITIONS[name].headers;
+      let sheet = ss.getSheetByName(name);
+      if (!sheet) {
+        sheet = ss.insertSheet(name);
+      }
+      ensureHeaders_(sheet, headers);
+      sheets[name] = { sheet: sheet, headers: headers };
+    });
+    return { success: true, data: { ss: ss, sheets: sheets } };
+  } catch (err) {
+    return { success: false, message: 'INVALID_SPREADSHEET_ID' };
+  }
+}
+
+function ensureHeaders_(sheet, headers) {
+  const width = headers.length;
+  if (sheet.getMaxColumns() < width) {
+    sheet.insertColumnsAfter(sheet.getMaxColumns(), width - sheet.getMaxColumns());
+  }
+  sheet.getRange(1, 1, 1, width).setValues([headers]);
+  sheet.setFrozenRows(1);
+}
+
+function uuid_() {
+  return Utilities.getUuid();
+}
+
+function todayISO_() {
+  return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+}
+
+function nowISODateTime_() {
+  return Utilities.formatDate(new Date(), Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm:ssXXX");
+}
+
+function hash_(s) {
+  const digest = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, s || '');
+  return Utilities.base64Encode(digest);
+}
+
+function getSessionContext_(options) {
+  options = options || {};
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  const data = env.data;
+  const email = getCurrentEmail_();
+  if (!email) {
+    return { success: false, message: 'GOOGLE_SIGN_IN_REQUIRED' };
+  }
+  const usersSheet = data.sheets.Users.sheet;
+  const headers = SHEET_DEFINITIONS.Users.headers;
+  const table = loadTable_(usersSheet, headers);
+  const entry = table.find(function (row) {
+    return (row.record.email || '').toLowerCase() === email.toLowerCase();
+  });
+  if (!entry) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  if (!toBool_(entry.record.isActive)) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const user = sanitizeUser_(entry.record);
+  if (options.includePrefs) {
+    user.preferences = getNotificationPrefs_(user.id);
+  }
+  const context = {
+    env: data,
+    email: email,
+    user: user,
+    userEntry: entry,
+    usersTable: table
+  };
+  if (options.includeUsers) {
+    context.users = table.map(function (row) {
+      return sanitizeUser_(row.record);
+    });
+  }
+  return { success: true, data: context };
+}
+
+function getCurrentEmail_() {
+  return (Session.getActiveUser().getEmail() || Session.getEffectiveUser().getEmail() || '').trim();
+}
+
+function isRoleAtLeast_(role, minimum) {
+  role = role || 'USER';
+  minimum = minimum || 'USER';
+  return ROLE_ORDER.indexOf(role) <= ROLE_ORDER.indexOf(minimum);
+}
+
+function sanitizeUser_(record) {
+  return {
+    id: record.id || '',
+    firstName: record.firstName || '',
+    lastName: record.lastName || '',
+    email: record.email || '',
+    role: record.role || 'USER',
+    parentUserId: record.parentUserId || '',
+    notificationEmail: record.notificationEmail || record.email || '',
+    tutorialSeen: toBool_(record.tutorialSeen),
+    isActive: toBool_(record.isActive),
+    createdAt: record.createdAt || '',
+    updatedAt: record.updatedAt || ''
+  };
+}
+
+function currentSession() {
+  const ctx = getSessionContext_({ includePrefs: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  return {
+    success: true,
+    data: {
+      email: ctx.data.email,
+      user: ctx.data.user
+    }
+  };
+}
+
+function adminQuickAddSelf(payload) {
+  payload = payload || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const me = ctx.data.user;
+  if (!isRoleAtLeast_(me.role, 'ADMIN')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const email = ctx.data.email.toLowerCase();
+  const exists = ctx.data.usersTable.find(function (entry) {
+    return (entry.record.email || '').toLowerCase() === email;
+  });
+  if (exists) {
+    return { success: false, message: 'ALREADY_EXISTS' };
+  }
+  const now = todayISO_();
+  const record = {
+    id: uuid_(),
+    firstName: payload.firstName || '',
+    lastName: payload.lastName || '',
+    email: ctx.data.email,
+    passwordHash: '',
+    role: ROLE_ORDER.indexOf(payload.role) >= 0 ? payload.role : 'ADMIN',
+    parentUserId: me.id,
+    notificationEmail: payload.notificationEmail || ctx.data.email,
+    tutorialSeen: 'FALSE',
+    isActive: 'TRUE',
+    createdAt: now,
+    updatedAt: now
+  };
+  appendRecord_(ctx.data.env.sheets.Users.sheet, SHEET_DEFINITIONS.Users.headers, record);
+  return { success: true, data: sanitizeUser_(record) };
+}
+
+function createUserFromUI(user) {
+  user = user || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const creator = ctx.data.user;
+  if (!isRoleAtLeast_(creator.role, 'MANAGER')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const required = ['firstName', 'email', 'role', 'notificationEmail'];
+  const missing = required.filter(function (field) {
+    return !user[field];
+  });
+  if (missing.length) {
+    return { success: false, message: 'MISSING_' + missing.join('_') };
+  }
+  const email = (user.email || '').toLowerCase();
+  const exists = ctx.data.usersTable.find(function (entry) {
+    return (entry.record.email || '').toLowerCase() === email;
+  });
+  if (exists) {
+    return { success: false, message: 'EMAIL_IN_USE' };
+  }
+  const now = todayISO_();
+  const record = {
+    id: uuid_(),
+    firstName: user.firstName || '',
+    lastName: user.lastName || '',
+    email: user.email,
+    passwordHash: user.passwordHash || '',
+    role: ROLE_ORDER.indexOf(user.role) >= 0 ? user.role : 'USER',
+    parentUserId: creator.id,
+    notificationEmail: user.notificationEmail || user.email,
+    tutorialSeen: user.tutorialSeen ? 'TRUE' : 'FALSE',
+    isActive: 'TRUE',
+    createdAt: now,
+    updatedAt: now
+  };
+  appendRecord_(ctx.data.env.sheets.Users.sheet, SHEET_DEFINITIONS.Users.headers, record);
+  return { success: true, data: sanitizeUser_(record) };
+}
+
+function listUsers(params) {
+  params = params || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  let users = ctx.data.users || [];
+  const viewer = ctx.data.user;
+  if (!isRoleAtLeast_(viewer.role, 'ADMIN')) {
+    if (viewer.role === 'MANAGER') {
+      users = users.filter(function (u) {
+        return u.id === viewer.id || u.parentUserId === viewer.id;
+      });
+    } else {
+      users = users.filter(function (u) {
+        return u.id === viewer.id;
+      });
+    }
+  }
+  return { success: true, data: users };
+}
+
+function saveEmailSettings(payload) {
+  payload = payload || {};
+  const ctx = getSessionContext_({ includePrefs: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const record = ctx.data.userEntry.record;
+  if (payload.notificationEmail) {
+    record.notificationEmail = payload.notificationEmail;
+  }
+  if (payload.tutorialSeen === true) {
+    record.tutorialSeen = 'TRUE';
+  }
+  record.updatedAt = todayISO_();
+  writeRecord_(ctx.data.env.sheets.Users.sheet, SHEET_DEFINITIONS.Users.headers, ctx.data.userEntry.rowNumber, record);
+  saveNotificationPrefs_(ctx.data.user.id, {
+    instant: payload.instant !== false,
+    daily: payload.daily !== false,
+    weekly: payload.weekly !== false
+  });
+  const updated = sanitizeUser_(record);
+  updated.preferences = getNotificationPrefs_(ctx.data.user.id);
+  return { success: true, data: updated };
+}
+
+function getTasks(params) {
+  params = params || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const requester = ctx.data.user;
+  const env = ctx.data.env;
+  const tasksSheet = env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const table = loadTable_(tasksSheet, headers);
+  const users = ctx.data.users || ctx.data.usersTable.map(function (entry) {
+    return sanitizeUser_(entry.record);
+  });
+  const visibility = buildVisibilityEmails_(requester, users);
+  const view = (params.view || 'my').toLowerCase();
+  let allowed;
+  if (view === 'all') {
+    allowed = visibility.all;
+  } else if (view === 'team') {
+    allowed = visibility.team.length ? visibility.team : visibility.all;
+  } else {
+    allowed = visibility.my.length ? visibility.my : visibility.all;
+  }
+  const includeDone = params.includeDone === true;
+  const statusFilters = (params.statusFilters || []).filter(function (s) {
+    return STATUSES.indexOf(s) !== -1;
+  });
+  const overdueOnly = params.overdueOnly === true;
+  const search = (params.q || '').toLowerCase();
+  const sortBy = ['priority', 'status'].indexOf(params.sortBy) !== -1 ? params.sortBy : 'dueDate';
+  const sortDir = (params.sortDir || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc';
+  const pageSize = Math.min(200, Math.max(1, params.pageSize || 50));
+  const startIndex = Math.max(0, parseInt(params.pageToken, 10) || 0);
+  const today = todayISO_();
+
+  let rows = table.map(function (entry) {
+    return sanitizeTask_(entry.record);
+  });
+
+  rows = rows.filter(function (task) {
+    if (!task.assignedTo) {
+      return false;
+    }
+    if (allowed.length && allowed.indexOf(task.assignedTo.toLowerCase()) === -1) {
+      return false;
+    }
+    if (!includeDone && task.status === 'Done') {
+      return false;
+    }
+    if (statusFilters.length && statusFilters.indexOf(task.status) === -1) {
+      return false;
+    }
+    if (overdueOnly) {
+      if (!task.dueDate || task.status === 'Done' || task.dueDate >= today) {
+        return false;
+      }
+    }
+    if (search) {
+      const haystack = [
+        task.title,
+        task.description,
+        task.assignedTo,
+        task.priority,
+        task.status,
+        task.tags,
+        task.links
+      ]
+        .join(' ')
+        .toLowerCase();
+      if (haystack.indexOf(search) === -1) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  rows.sort(function (a, b) {
+    const dir = sortDir === 'desc' ? -1 : 1;
+    if (sortBy === 'priority') {
+      return (PRIORITIES.indexOf(a.priority) - PRIORITIES.indexOf(b.priority)) * dir;
+    }
+    if (sortBy === 'status') {
+      return (STATUSES.indexOf(a.status) - STATUSES.indexOf(b.status)) * dir;
+    }
+    const av = a.dueDate || '';
+    const bv = b.dueDate || '';
+    if (!av && !bv) {
+      return a.title.localeCompare(b.title) * dir;
+    }
+    if (!av) {
+      return 1 * dir;
+    }
+    if (!bv) {
+      return -1 * dir;
+    }
+    if (av === bv) {
+      return a.title.localeCompare(b.title) * dir;
+    }
+    return (av > bv ? 1 : -1) * dir;
+  });
+
+  const totals = computeTaskTotals_(rows, requester.email);
+  const page = rows.slice(startIndex, startIndex + pageSize);
+  const nextPageToken = startIndex + pageSize < rows.length ? String(startIndex + pageSize) : '';
+
+  return {
+    success: true,
+    data: {
+      rows: page,
+      nextPageToken: nextPageToken,
+      totals: totals
+    }
+  };
+}
+
+function createTask(task) {
+  task = task || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const requester = ctx.data.user;
+  const users = ctx.data.users || ctx.data.usersTable.map(function (entry) {
+    return sanitizeUser_(entry.record);
+  });
+  const assignedEmail = (task.assignedTo || '').toLowerCase();
+  const assignee = users.find(function (u) {
+    return u.email.toLowerCase() === assignedEmail && u.isActive;
+  });
+  if (!assignee) {
+    return { success: false, message: 'INVALID_ASSIGNEE' };
+  }
+  const record = {
+    id: uuid_(),
+    title: task.title || 'Untitled Task',
+    description: task.description || '',
+    assignedTo: assignee.email,
+    priority: PRIORITIES.indexOf(task.priority) >= 0 ? task.priority : 'Normal',
+    status: STATUSES.indexOf(task.status) >= 0 ? task.status : 'Todo',
+    dueDate: normalizeDate_(task.dueDate),
+    estimatedHours: Number(task.estimatedHours) || 0,
+    tags: task.tags || '',
+    links: task.links || '',
+    createdBy: requester.email,
+    createdAt: todayISO_(),
+    updatedAt: todayISO_(),
+    totalSeconds: 0
+  };
+  appendRecord_(ctx.data.env.sheets.Tasks.sheet, SHEET_DEFINITIONS.Tasks.headers, record);
+  const cc = [];
+  if (requester.notificationEmail) {
+    cc.push(requester.notificationEmail);
+  }
+  if (requester.email && cc.indexOf(requester.email) === -1) {
+    cc.push(requester.email);
+  }
+  sendOnAssignment_(record, assignee.email, cc);
+  return { success: true, data: sanitizeTask_(record) };
+}
+
+function updateTask(task) {
+  task = task || {};
+  if (!task.id) {
+    return { success: false, message: 'TASK_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const env = ctx.data.env;
+  const sheet = env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const table = loadTable_(sheet, headers);
+  const entry = table.find(function (row) {
+    return row.record.id === task.id;
+  });
+  if (!entry) {
+    return { success: false, message: 'NOT_FOUND' };
+  }
+  const requester = ctx.data.user;
+  if (!canInteractWithTask_(requester, entry.record, ctx.data.usersTable)) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const users = ctx.data.users || ctx.data.usersTable.map(function (u) {
+    return sanitizeUser_(u.record);
+  });
+  const previousAssignee = entry.record.assignedTo;
+  const nextAssigneeEmail = (task.assignedTo || previousAssignee || '').toLowerCase();
+  const nextAssignee = users.find(function (u) {
+    return u.email.toLowerCase() === nextAssigneeEmail && u.isActive;
+  });
+  if (!nextAssignee) {
+    return { success: false, message: 'INVALID_ASSIGNEE' };
+  }
+  entry.record.title = task.title !== undefined ? task.title : entry.record.title;
+  entry.record.description = task.description !== undefined ? task.description : entry.record.description;
+  entry.record.assignedTo = nextAssignee.email;
+  if (STATUSES.indexOf(task.status) !== -1) {
+    entry.record.status = task.status;
+  }
+  if (PRIORITIES.indexOf(task.priority) !== -1) {
+    entry.record.priority = task.priority;
+  }
+  const normalizedDue = normalizeDate_(task.dueDate);
+  if (normalizedDue || task.dueDate === '') {
+    entry.record.dueDate = normalizedDue;
+  }
+  if (task.estimatedHours !== undefined) {
+    entry.record.estimatedHours = Number(task.estimatedHours) || 0;
+  }
+  if (task.tags !== undefined) {
+    entry.record.tags = task.tags;
+  }
+  if (task.links !== undefined) {
+    entry.record.links = task.links;
+  }
+  entry.record.updatedAt = todayISO_();
+  writeRecord_(sheet, headers, entry.rowNumber, entry.record);
+  if ((previousAssignee || '').toLowerCase() !== entry.record.assignedTo.toLowerCase()) {
+    const cc = [];
+    if (requester.notificationEmail) {
+      cc.push(requester.notificationEmail);
+    }
+    if (requester.email && cc.indexOf(requester.email) === -1) {
+      cc.push(requester.email);
+    }
+    sendOnAssignment_(entry.record, entry.record.assignedTo, cc);
+  }
+  return { success: true, data: sanitizeTask_(entry.record) };
+}
+
+function markDone(payload) {
+  payload = payload || {};
+  if (!payload.taskId) {
+    return { success: false, message: 'TASK_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const env = ctx.data.env;
+  const sheet = env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const table = loadTable_(sheet, headers);
+  const entry = table.find(function (row) {
+    return row.record.id === payload.taskId;
+  });
+  if (!entry) {
+    return { success: false, message: 'NOT_FOUND' };
+  }
+  if (!canInteractWithTask_(ctx.data.user, entry.record, ctx.data.usersTable)) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  entry.record.status = 'Done';
+  entry.record.updatedAt = todayISO_();
+  writeRecord_(sheet, headers, entry.rowNumber, entry.record);
+  return { success: true, data: sanitizeTask_(entry.record) };
+}
+
+function startTimer(taskId) {
+  if (!taskId) {
+    return { success: false, message: 'TASK_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const env = ctx.data.env;
+  const tasksSheet = env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const table = loadTable_(tasksSheet, headers);
+  const entry = table.find(function (row) {
+    return row.record.id === taskId;
+  });
+  if (!entry) {
+    return { success: false, message: 'NOT_FOUND' };
+  }
+  if (!canInteractWithTask_(ctx.data.user, entry.record, ctx.data.usersTable)) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const record = {
+    id: uuid_(),
+    taskId: taskId,
+    userEmail: ctx.data.user.email,
+    startedAt: nowISODateTime_(),
+    stoppedAt: '',
+    durationSeconds: 0
+  };
+  appendRecord_(env.sheets.TimeLog.sheet, SHEET_DEFINITIONS.TimeLog.headers, record);
+  return { success: true, data: record };
+}
+
+function stopTimer(taskId) {
+  if (!taskId) {
+    return { success: false, message: 'TASK_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const env = ctx.data.env;
+  const timeSheet = env.sheets.TimeLog.sheet;
+  const headers = SHEET_DEFINITIONS.TimeLog.headers;
+  const table = loadTable_(timeSheet, headers);
+  const entry = table.reverse().find(function (row) {
+    return row.record.taskId === taskId && (row.record.userEmail || '').toLowerCase() === ctx.data.user.email.toLowerCase() && !row.record.stoppedAt;
+  });
+  if (!entry) {
+    return { success: false, message: 'TIMER_NOT_FOUND' };
+  }
+  const stopTime = nowISODateTime_();
+  const duration = Math.max(1, Math.floor((new Date(stopTime) - new Date(entry.record.startedAt)) / 1000));
+  entry.record.stoppedAt = stopTime;
+  entry.record.durationSeconds = duration;
+  writeRecord_(timeSheet, headers, entry.rowNumber, entry.record);
+  accumulateTaskTime_(env, taskId);
+  return { success: true, data: entry.record };
+}
+
+function bulkImportTasks(rows) {
+  rows = rows || [];
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  if (!isRoleAtLeast_(ctx.data.user.role, 'MANAGER')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const users = ctx.data.users || ctx.data.usersTable.map(function (entry) {
+    return sanitizeUser_(entry.record);
+  });
+  const sheet = ctx.data.env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const errors = [];
+  let count = 0;
+  rows.forEach(function (row, index) {
+    const assignedTo = (row.assignedTo || '').toLowerCase();
+    const assignee = users.find(function (u) {
+      return u.email.toLowerCase() === assignedTo && u.isActive;
+    });
+    if (!assignee) {
+      errors.push({ index: index, message: 'INVALID_ASSIGNEE' });
+      return;
+    }
+    const record = {
+      id: uuid_(),
+      title: row.title || 'Untitled Task',
+      description: row.description || '',
+      assignedTo: assignee.email,
+      priority: PRIORITIES.indexOf(row.priority) >= 0 ? row.priority : 'Normal',
+      status: STATUSES.indexOf(row.status) >= 0 ? row.status : 'Todo',
+      dueDate: normalizeDate_(row.dueDate),
+      estimatedHours: Number(row.estimatedHours) || 0,
+      tags: row.tags || '',
+      links: row.links || '',
+      createdBy: ctx.data.user.email,
+      createdAt: todayISO_(),
+      updatedAt: todayISO_(),
+      totalSeconds: 0
+    };
+    appendRecord_(sheet, headers, record);
+    count++;
+  });
+  return { success: true, count: count, errors: errors };
+}
+
+function exportTasksCSV(params) {
+  params = params || {};
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ContentService.createTextOutput(JSON.stringify(ctx));
+  }
+  const response = getTasks(params);
+  if (!response.success) {
+    return ContentService.createTextOutput(JSON.stringify(response));
+  }
+  const headers = ['title', 'description', 'assignedTo', 'priority', 'status', 'dueDate', 'estimatedHours', 'tags', 'links'];
+  const lines = [headers.join(',')];
+  response.data.rows.forEach(function (task) {
+    const row = headers.map(function (key) {
+      const value = task[key] !== undefined && task[key] !== null ? String(task[key]) : '';
+      if (value.indexOf(',') > -1 || value.indexOf('"') > -1 || value.indexOf('\n') > -1) {
+        return '"' + value.replace(/"/g, '""') + '"';
+      }
+      return value;
+    });
+    lines.push(row.join(','));
+  });
+  return ContentService.createTextOutput(lines.join('\n')).setMimeType(ContentService.MimeType.CSV);
+}
+
+function getDashboardMetrics() {
+  const ctx = getSessionContext_({ includeUsers: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const env = ctx.data.env;
+  const tasksSheet = env.sheets.Tasks.sheet;
+  const headers = SHEET_DEFINITIONS.Tasks.headers;
+  const table = loadTable_(tasksSheet, headers);
+  const users = ctx.data.users || ctx.data.usersTable.map(function (entry) {
+    return sanitizeUser_(entry.record);
+  });
+  const visibility = buildVisibilityEmails_(ctx.data.user, users);
+  const allowed = visibility.all;
+  const tasks = table
+    .map(function (row) {
+      return sanitizeTask_(row.record);
+    })
+    .filter(function (task) {
+      return allowed.indexOf(task.assignedTo.toLowerCase()) !== -1;
+    });
+  const totals = computeTaskTotals_(tasks, ctx.data.user.email);
+  const today = todayISO_();
+  const dueSoonLimit = addDays_(today, 3);
+  const overdue = tasks.filter(function (task) {
+    return task.dueDate && task.dueDate < today && task.status !== 'Done';
+  }).length;
+  const dueSoon = tasks.filter(function (task) {
+    return task.dueDate && task.dueDate >= today && task.dueDate <= dueSoonLimit && task.status !== 'Done';
+  }).length;
+  const myTasks = tasks.filter(function (task) {
+    return task.assignedTo.toLowerCase() === ctx.data.user.email.toLowerCase();
+  });
+  return {
+    success: true,
+    data: {
+      total: tasks.length,
+      byStatus: totals.byStatus,
+      overdue: overdue,
+      dueSoon: dueSoon,
+      myTotals: computeTaskTotals_(myTasks, ctx.data.user.email),
+      teamTotals: totals
+    }
+  };
+}
+
+function listTools(params) {
+  params = params || {};
+  const ctx = getSessionContext_({ includeUsers: false });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const includeInactive = params.includeInactive && isRoleAtLeast_(ctx.data.user.role, 'ADMIN');
+  const sheet = ctx.data.env.sheets.Tools.sheet;
+  const headers = SHEET_DEFINITIONS.Tools.headers;
+  const table = loadTable_(sheet, headers);
+  const tools = table
+    .map(function (row) {
+      return sanitizeTool_(row.record);
+    })
+    .filter(function (tool) {
+      return includeInactive || tool.isActive;
+    })
+    .sort(function (a, b) {
+      return a.sortOrder - b.sortOrder;
+    });
+  return { success: true, data: tools };
+}
+
+function createTool(tool) {
+  tool = tool || {};
+  const ctx = getSessionContext_({ includeUsers: false });
+  if (!ctx.success) {
+    return ctx;
+  }
+  if (!isRoleAtLeast_(ctx.data.user.role, 'ADMIN')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const record = {
+    id: uuid_(),
+    iconUrl: tool.iconUrl || '',
+    name: tool.name || '',
+    toolUrl: tool.toolUrl || '',
+    isActive: tool.isActive === false ? 'FALSE' : 'TRUE',
+    createdAt: todayISO_(),
+    updatedAt: todayISO_(),
+    sortOrder: Number(tool.sortOrder) || 0
+  };
+  appendRecord_(ctx.data.env.sheets.Tools.sheet, SHEET_DEFINITIONS.Tools.headers, record);
+  return { success: true, data: sanitizeTool_(record) };
+}
+
+function updateTool(tool) {
+  tool = tool || {};
+  if (!tool.id) {
+    return { success: false, message: 'TOOL_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: false });
+  if (!ctx.success) {
+    return ctx;
+  }
+  if (!isRoleAtLeast_(ctx.data.user.role, 'ADMIN')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const sheet = ctx.data.env.sheets.Tools.sheet;
+  const headers = SHEET_DEFINITIONS.Tools.headers;
+  const table = loadTable_(sheet, headers);
+  const entry = table.find(function (row) {
+    return row.record.id === tool.id;
+  });
+  if (!entry) {
+    return { success: false, message: 'NOT_FOUND' };
+  }
+  if (tool.iconUrl !== undefined) {
+    entry.record.iconUrl = tool.iconUrl;
+  }
+  if (tool.name !== undefined) {
+    entry.record.name = tool.name;
+  }
+  if (tool.toolUrl !== undefined) {
+    entry.record.toolUrl = tool.toolUrl;
+  }
+  if (tool.isActive !== undefined) {
+    entry.record.isActive = tool.isActive ? 'TRUE' : 'FALSE';
+  }
+  if (tool.sortOrder !== undefined) {
+    entry.record.sortOrder = Number(tool.sortOrder) || 0;
+  }
+  entry.record.updatedAt = todayISO_();
+  writeRecord_(sheet, headers, entry.rowNumber, entry.record);
+  return { success: true, data: sanitizeTool_(entry.record) };
+}
+
+function deleteTool(payload) {
+  const id = typeof payload === 'string' ? payload : (payload && payload.id);
+  if (!id) {
+    return { success: false, message: 'TOOL_ID_REQUIRED' };
+  }
+  const ctx = getSessionContext_({ includeUsers: false });
+  if (!ctx.success) {
+    return ctx;
+  }
+  if (!isRoleAtLeast_(ctx.data.user.role, 'ADMIN')) {
+    return { success: false, message: 'ACCESS_DENIED' };
+  }
+  const sheet = ctx.data.env.sheets.Tools.sheet;
+  const headers = SHEET_DEFINITIONS.Tools.headers;
+  const table = loadTable_(sheet, headers);
+  const entry = table.find(function (row) {
+    return row.record.id === id;
+  });
+  if (!entry) {
+    return { success: false, message: 'NOT_FOUND' };
+  }
+  entry.record.isActive = 'FALSE';
+  entry.record.updatedAt = todayISO_();
+  writeRecord_(sheet, headers, entry.rowNumber, entry.record);
+  return { success: true, data: sanitizeTool_(entry.record) };
+}
+
+function sendOnAssignment_(task, assigneeEmail, ccEmails) {
+  if (!assigneeEmail) {
+    return { success: false, message: 'NO_ASSIGNEE' };
+  }
+  const url = getAppUrl_();
+  const cc = dedupeArray_((ccEmails || []).filter(Boolean));
+  const subject = '[AuraFlow] Task Assigned: ' + (task.title || 'Task');
+  const due = task.dueDate ? '<p><strong>Due Date:</strong> ' + task.dueDate + '</p>' : '';
+  const estimated = Number(task.estimatedHours) ? '<p><strong>Estimated Hours:</strong> ' + Number(task.estimatedHours) + '</p>' : '';
+  const html = [
+    '<div style="font-family:Roboto,Arial,sans-serif;color:#202124;">',
+    '<div style="display:flex;align-items:center;gap:8px;margin-bottom:16px;">',
+    '<img src="' + BRAND_LOGO_URL + '" alt="AuraFlow" style="height:28px;width:28px;">',
+    '<span style="font-size:20px;font-weight:600;">AuraFlow</span>',
+    '</div>',
+    '<div style="background:#ffffff;border:1px solid #e0e0e0;border-radius:12px;padding:20px;box-shadow:0 2px 8px rgba(0,0,0,0.08);">',
+    '<h2 style="margin:0 0 8px;font-size:18px;">New Task Assigned</h2>',
+    '<p style="margin:0 0 12px;color:#5f6368;">' + (task.createdBy ? 'Assigned by ' + task.createdBy : 'New assignment') + '</p>',
+    '<p><strong>Title:</strong> ' + (task.title || 'Task') + '</p>',
+    (task.description ? '<p><strong>Description:</strong><br>' + sanitizeHtml_(task.description) + '</p>' : ''),
+    due,
+    estimated,
+    '<p><strong>Status:</strong> ' + (task.status || 'Todo') + '</p>',
+    '<a href="' + url + '" style="display:inline-block;margin-top:12px;padding:10px 18px;background:#1a73e8;color:#fff;border-radius:6px;text-decoration:none;font-weight:500;">View Task</a>',
+    '</div>',
+    brandFooterHtml_(),
+    '</div>'
+  ].join('');
+  try {
+    MailApp.sendEmail({
+      to: assigneeEmail,
+      subject: subject,
+      htmlBody: html,
+      body: 'A task has been assigned to you in AuraFlow. View it here: ' + url,
+      cc: cc.join(','),
+      name: 'AuraFlow'
+    });
+  } catch (err) {
+    Logger.log('Assignment email failed: ' + err);
+  }
+  return { success: true };
+}
+
+function dailyDigestRunner() {
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  sendDigestEmails_(env.data, 'daily');
+  return { success: true };
+}
+
+function weeklyDigestRunner() {
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  sendDigestEmails_(env.data, 'weekly');
+  return { success: true };
+}
+
+function initializeApp(options) {
+  options = options || {};
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  let triggerResult;
+  try {
+    triggerResult = setupTriggers();
+  } catch (err) {
+    triggerResult = { success: false, message: err.message };
+  }
+  let demoResult = null;
+  if (options.createDemoData || options.seedDemoData) {
+    demoResult = createDemoData(options);
+  }
+  const response = {
+    success: true,
+    message: 'APP_INITIALIZED',
+    data: {
+      sheetsEnsured: Object.keys(env.data.sheets),
+      triggers: triggerResult,
+      demo: demoResult
+    }
+  };
+  if (triggerResult && triggerResult.success === false) {
+    response.success = false;
+    response.message = triggerResult.message || 'TRIGGER_SETUP_FAILED';
+  }
+  if (demoResult && demoResult.success === false) {
+    response.success = false;
+    response.message = demoResult.message || 'DEMO_DATA_FAILED';
+  }
+  return response;
+}
+
+function createDemoData(options) {
+  options = options || {};
+  const env = ensureSpreadsheet_();
+  if (!env.success) {
+    return env;
+  }
+  try {
+    const data = env.data;
+    const today = todayISO_();
+    const timezone = Session.getScriptTimeZone();
+    const summary = {
+      usersCreated: 0,
+      tasksCreated: 0,
+      timeLogsCreated: 0,
+      toolsCreated: 0
+    };
+
+    const usersSheet = data.sheets.Users.sheet;
+    const userHeaders = SHEET_DEFINITIONS.Users.headers;
+    const userRows = loadTable_(usersSheet, userHeaders);
+    const userByEmail = {};
+    userRows.forEach(function (entry) {
+      const email = (entry.record.email || '').toLowerCase();
+      if (!email) {
+        return;
+      }
+      if (!entry.record.id) {
+        entry.record.id = uuid_();
+        if (!entry.record.createdAt) {
+          entry.record.createdAt = today;
+        }
+        entry.record.updatedAt = today;
+        writeRecord_(usersSheet, userHeaders, entry.rowNumber, entry.record);
+      }
+      userByEmail[email] = entry;
+    });
+
+    const sampleUsers = [
+      {
+        email: 'mananvermabusiness@gmail.com',
+        firstName: 'Manan',
+        lastName: 'Verma',
+        role: 'MASTER_ADMIN',
+        notificationEmail: 'mananvermabusiness@gmail.com',
+        tutorialSeen: true
+      },
+      {
+        email: 'operations@auraflow.app',
+        firstName: 'Operations',
+        lastName: 'Lead',
+        role: 'ADMIN',
+        notificationEmail: 'operations@auraflow.app',
+        parentEmail: 'mananvermabusiness@gmail.com'
+      },
+      {
+        email: 'manager@auraflow.app',
+        firstName: 'Taylor',
+        lastName: 'Lee',
+        role: 'MANAGER',
+        notificationEmail: 'manager@auraflow.app',
+        parentEmail: 'operations@auraflow.app'
+      },
+      {
+        email: 'teammate@auraflow.app',
+        firstName: 'Jordan',
+        lastName: 'Chen',
+        role: 'USER',
+        notificationEmail: 'teammate@auraflow.app',
+        parentEmail: 'manager@auraflow.app'
+      }
+    ];
+
+    function getParentId(parentEmail) {
+      if (!parentEmail) {
+        return '';
+      }
+      const parentEntry = userByEmail[parentEmail.toLowerCase()];
+      return parentEntry && parentEntry.record.id ? parentEntry.record.id : '';
+    }
+
+    sampleUsers.forEach(function (def) {
+      const key = def.email.toLowerCase();
+      let entry = userByEmail[key];
+      if (entry) {
+        let mutated = false;
+        if (!entry.record.id) {
+          entry.record.id = uuid_();
+          mutated = true;
+        }
+        if (!entry.record.notificationEmail && def.notificationEmail) {
+          entry.record.notificationEmail = def.notificationEmail;
+          mutated = true;
+        }
+        if (!entry.record.parentUserId && def.parentEmail) {
+          const parentId = getParentId(def.parentEmail);
+          if (parentId) {
+            entry.record.parentUserId = parentId;
+            mutated = true;
+          }
+        }
+        if (!entry.record.isActive) {
+          entry.record.isActive = 'TRUE';
+          mutated = true;
+        }
+        if (mutated) {
+          entry.record.updatedAt = today;
+          writeRecord_(usersSheet, userHeaders, entry.rowNumber, entry.record);
+        }
+        return;
+      }
+      const record = {
+        id: uuid_(),
+        firstName: def.firstName || '',
+        lastName: def.lastName || '',
+        email: def.email,
+        passwordHash: '',
+        role: def.role || 'USER',
+        parentUserId: getParentId(def.parentEmail),
+        notificationEmail: def.notificationEmail || def.email,
+        tutorialSeen: def.tutorialSeen ? 'TRUE' : 'FALSE',
+        isActive: 'TRUE',
+        createdAt: today,
+        updatedAt: today
+      };
+      const rowNumber = appendRecord_(usersSheet, userHeaders, record);
+      entry = { rowNumber: rowNumber, record: record };
+      userByEmail[key] = entry;
+      summary.usersCreated += 1;
+    });
+
+    function getUserRecord(email) {
+      if (!email) {
+        return null;
+      }
+      const entry = userByEmail[email.toLowerCase()];
+      return entry ? entry.record : null;
+    }
+
+    const tasksSheet = data.sheets.Tasks.sheet;
+    const taskHeaders = SHEET_DEFINITIONS.Tasks.headers;
+    const taskRows = loadTable_(tasksSheet, taskHeaders);
+    const tasksByTitle = {};
+    taskRows.forEach(function (entry) {
+      const titleKey = (entry.record.title || '').toLowerCase();
+      if (!titleKey) {
+        return;
+      }
+      if (!entry.record.id) {
+        entry.record.id = uuid_();
+        if (!entry.record.createdAt) {
+          entry.record.createdAt = today;
+        }
+        entry.record.updatedAt = today;
+        writeRecord_(tasksSheet, taskHeaders, entry.rowNumber, entry.record);
+      }
+      tasksByTitle[titleKey] = entry;
+    });
+
+    const sampleTasks = [
+      {
+        title: 'Finalize AuraFlow onboarding checklist',
+        description: 'Document the onboarding flow and share it with new collaborators.',
+        assignedTo: 'teammate@auraflow.app',
+        priority: 'High',
+        status: 'Doing',
+        dueOffset: 2,
+        estimatedHours: 6,
+        tags: 'onboarding,process',
+        links: 'https://auraflow.one/wiki/onboarding',
+        createdBy: 'operations@auraflow.app',
+        logs: [
+          { userEmail: 'teammate@auraflow.app', startTime: '09:00', durationMinutes: 90, dateOffset: -1 },
+          { userEmail: 'teammate@auraflow.app', startTime: '11:00', durationMinutes: 60, dateOffset: -1 }
+        ]
+      },
+      {
+        title: 'Prepare weekly executive summary',
+        description: 'Compile highlights, blockers, and wins for leadership review.',
+        assignedTo: 'manager@auraflow.app',
+        priority: 'Normal',
+        status: 'Todo',
+        dueOffset: 3,
+        estimatedHours: 4,
+        tags: 'reporting,leadership',
+        links: 'https://auraflow.one/docs/executive-summary',
+        createdBy: 'mananvermabusiness@gmail.com',
+        logs: [
+          { userEmail: 'manager@auraflow.app', startTime: '14:00', durationMinutes: 45, dateOffset: 0 }
+        ]
+      },
+      {
+        title: 'Backlog triage and grooming',
+        description: 'Review incoming requests, prioritize, and clarify requirements.',
+        assignedTo: 'operations@auraflow.app',
+        priority: 'Low',
+        status: 'Blocked',
+        dueOffset: -1,
+        estimatedHours: 2,
+        tags: 'planning,triage',
+        links: 'https://auraflow.one/boards/backlog',
+        createdBy: 'mananvermabusiness@gmail.com',
+        logs: []
+      }
+    ];
+
+    const seededTasks = [];
+
+    sampleTasks.forEach(function (def) {
+      const assigned = getUserRecord(def.assignedTo);
+      if (!assigned) {
+        return;
+      }
+      const titleKey = (def.title || '').toLowerCase();
+      if (!titleKey) {
+        return;
+      }
+      if (tasksByTitle[titleKey]) {
+        seededTasks.push({ def: def, record: tasksByTitle[titleKey].record, created: false });
+        return;
+      }
+      const dueDate = typeof def.dueOffset === 'number' ? addDays_(today, def.dueOffset) : (def.dueDate || '');
+      const logs = def.logs || [];
+      const totalSeconds = logs.reduce(function (sum, log) {
+        return sum + (Number(log.durationMinutes) || 0) * 60;
+      }, 0);
+      const record = {
+        id: uuid_(),
+        title: def.title,
+        description: def.description || '',
+        assignedTo: def.assignedTo,
+        priority: PRIORITIES.indexOf(def.priority) >= 0 ? def.priority : 'Normal',
+        status: STATUSES.indexOf(def.status) >= 0 ? def.status : 'Todo',
+        dueDate: dueDate || '',
+        estimatedHours: Number(def.estimatedHours) || 0,
+        tags: def.tags || '',
+        links: def.links || '',
+        createdBy: def.createdBy || def.assignedTo,
+        createdAt: today,
+        updatedAt: today,
+        totalSeconds: totalSeconds
+      };
+      const rowNumber = appendRecord_(tasksSheet, taskHeaders, record);
+      const entry = { rowNumber: rowNumber, record: record };
+      tasksByTitle[titleKey] = entry;
+      seededTasks.push({ def: def, record: record, created: true });
+      summary.tasksCreated += 1;
+    });
+
+    const timeLogSheet = data.sheets.TimeLog.sheet;
+    const timeLogHeaders = SHEET_DEFINITIONS.TimeLog.headers;
+    const existingLogs = loadTable_(timeLogSheet, timeLogHeaders);
+    const logKeys = {};
+    existingLogs.forEach(function (entry) {
+      const key = (entry.record.taskId || '') + '|' + (entry.record.startedAt || '');
+      logKeys[key] = true;
+    });
+
+    function buildDateFromParts(isoDate, timeString) {
+      if (!isoDate) {
+        return new Date();
+      }
+      const dateParts = isoDate.split('-');
+      const timeParts = (timeString || '09:00').split(':');
+      const year = Number(dateParts[0]);
+      const month = Number(dateParts[1]) - 1;
+      const day = Number(dateParts[2]);
+      const hour = Number(timeParts[0]) || 0;
+      const minute = Number(timeParts[1]) || 0;
+      return new Date(year, month, day, hour, minute, 0, 0);
+    }
+
+    seededTasks.forEach(function (taskEntry) {
+      if (!taskEntry.created || !taskEntry.def.logs || !taskEntry.def.logs.length) {
+        return;
+      }
+      taskEntry.def.logs.forEach(function (logDef) {
+        const logDate = addDays_(today, typeof logDef.dateOffset === 'number' ? logDef.dateOffset : 0);
+        if (!logDate) {
+          return;
+        }
+        const startDate = buildDateFromParts(logDate, logDef.startTime || '09:00');
+        const durationSeconds = (Number(logDef.durationMinutes) || 0) * 60;
+        const stopDate = new Date(startDate.getTime() + durationSeconds * 1000);
+        const startedAt = Utilities.formatDate(startDate, timezone, "yyyy-MM-dd'T'HH:mm:ssXXX");
+        const stoppedAt = Utilities.formatDate(stopDate, timezone, "yyyy-MM-dd'T'HH:mm:ssXXX");
+        const key = taskEntry.record.id + '|' + startedAt;
+        if (logKeys[key]) {
+          return;
+        }
+        logKeys[key] = true;
+        const record = {
+          id: uuid_(),
+          taskId: taskEntry.record.id,
+          userEmail: logDef.userEmail || taskEntry.record.assignedTo,
+          startedAt: startedAt,
+          stoppedAt: stoppedAt,
+          durationSeconds: durationSeconds
+        };
+        appendRecord_(timeLogSheet, timeLogHeaders, record);
+        summary.timeLogsCreated += 1;
+      });
+    });
+
+    const toolsSheet = data.sheets.Tools.sheet;
+    const toolHeaders = SHEET_DEFINITIONS.Tools.headers;
+    const toolRows = loadTable_(toolsSheet, toolHeaders);
+    const toolsByName = {};
+    toolRows.forEach(function (entry) {
+      const key = (entry.record.name || '').toLowerCase();
+      if (key) {
+        toolsByName[key] = entry;
+      }
+    });
+
+    const sampleTools = [
+      {
+        name: 'AuraFlow Help Center',
+        iconUrl: BRAND_LOGO_URL,
+        toolUrl: 'https://auraflow.one/help',
+        isActive: true,
+        sortOrder: 1
+      },
+      {
+        name: 'Team Stand-up Room',
+        iconUrl: 'https://www.gstatic.com/images/branding/product/1x/meet_2020q4_48dp.png',
+        toolUrl: 'https://meet.google.com/',
+        isActive: true,
+        sortOrder: 2
+      },
+      {
+        name: 'Product Feedback Board',
+        iconUrl: 'https://www.gstatic.com/images/icons/material/system_gm/1x/assignment_turned_in_gm_blue_48dp.png',
+        toolUrl: 'https://workspace.google.com/marketplace/category/works-with-drive',
+        isActive: true,
+        sortOrder: 3
+      }
+    ];
+
+    sampleTools.forEach(function (def) {
+      const key = (def.name || '').toLowerCase();
+      if (!key || toolsByName[key]) {
+        return;
+      }
+      const record = {
+        id: uuid_(),
+        iconUrl: def.iconUrl || BRAND_LOGO_URL,
+        name: def.name,
+        toolUrl: def.toolUrl || '',
+        isActive: def.isActive === false ? 'FALSE' : 'TRUE',
+        createdAt: today,
+        updatedAt: today,
+        sortOrder: def.sortOrder !== undefined ? Number(def.sortOrder) : 0
+      };
+      appendRecord_(toolsSheet, toolHeaders, record);
+      summary.toolsCreated += 1;
+    });
+
+    const totalCreated = summary.usersCreated + summary.tasksCreated + summary.timeLogsCreated + summary.toolsCreated;
+    const message = totalCreated ? 'DEMO_DATA_CREATED' : 'DEMO_DATA_ALREADY_PRESENT';
+    return { success: true, message: message, data: summary };
+  } catch (err) {
+    return { success: false, message: err.message };
+  }
+}
+
+function setupTriggers() {
+  const triggers = ScriptApp.getProjectTriggers();
+  const managed = ['dailyDigestRunner', 'weeklyDigestRunner'];
+  triggers.forEach(function (trigger) {
+    if (managed.indexOf(trigger.getHandlerFunction()) !== -1) {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  });
+  ScriptApp.newTrigger('dailyDigestRunner')
+    .timeBased()
+    .everyDays(1)
+    .atHour(18)
+    .inTimezone('Asia/Kolkata')
+    .create();
+  ScriptApp.newTrigger('weeklyDigestRunner')
+    .timeBased()
+    .onWeekDay(ScriptApp.WeekDay.SUNDAY)
+    .atHour(10)
+    .inTimezone('Asia/Kolkata')
+    .create();
+  return { success: true, message: 'TRIGGERS_CONFIGURED' };
+}
+
+function sendTestEmail() {
+  const ctx = getSessionContext_({ includePrefs: true });
+  if (!ctx.success) {
+    return ctx;
+  }
+  const url = getAppUrl_();
+  const html = [
+    '<div style="font-family:Roboto,Arial,sans-serif;color:#202124;">',
+    '<div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">',
+    '<img src="' + BRAND_LOGO_URL + '" alt="AuraFlow" style="height:28px;width:28px;">',
+    '<span style="font-size:20px;font-weight:600;">AuraFlow</span>',
+    '</div>',
+    '<p>This is a sample notification from AuraFlow. Your notification email is set to <strong>' + (ctx.data.user.notificationEmail || ctx.data.user.email) + '</strong>.</p>',
+    '<p><a href="' + url + '" style="color:#1a73e8;">Open AuraFlow</a></p>',
+    brandFooterHtml_(),
+    '</div>'
+  ].join('');
+  try {
+    MailApp.sendEmail({
+      to: ctx.data.user.notificationEmail || ctx.data.user.email,
+      subject: '[AuraFlow] Notification Test',
+      htmlBody: html,
+      body: 'This is a test notification from AuraFlow. Open the app here: ' + url,
+      name: 'AuraFlow'
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, message: err.message };
+  }
+}
+
+function sendDigestEmails_(env, mode) {
+  const users = loadTable_(env.sheets.Users.sheet, SHEET_DEFINITIONS.Users.headers)
+    .map(function (row) { return sanitizeUser_(row.record); })
+    .filter(function (user) { return user.email && user.isActive; });
+  if (!users.length) {
+    return;
+  }
+  const tasks = loadTable_(env.sheets.Tasks.sheet, SHEET_DEFINITIONS.Tasks.headers)
+    .map(function (row) { return sanitizeTask_(row.record); });
+  const today = todayISO_();
+  const windowDays = mode === 'weekly' ? 7 : 1;
+  const windowEnd = addDays_(today, windowDays);
+  users.forEach(function (user) {
+    const visibility = buildVisibilityEmails_(user, users);
+    const allowed = visibility.all;
+    const visibleTasks = tasks.filter(function (task) {
+      return allowed.indexOf(task.assignedTo.toLowerCase()) !== -1;
+    });
+    const overdue = visibleTasks.filter(function (task) {
+      return task.dueDate && task.dueDate < today && task.status !== 'Done';
+    });
+    const upcoming = visibleTasks.filter(function (task) {
+      return task.dueDate && task.dueDate >= today && task.dueDate <= windowEnd && task.status !== 'Done';
+    });
+    if (!overdue.length && !upcoming.length) {
+      return;
+    }
+    const htmlSections = [];
+    if (overdue.length) {
+      htmlSections.push('<h3 style="margin:16px 0 8px;">Overdue Tasks</h3>');
+      htmlSections.push(renderTaskDigestList_(overdue));
+    }
+    if (upcoming.length) {
+      htmlSections.push('<h3 style="margin:16px 0 8px;">Upcoming Tasks</h3>');
+      htmlSections.push(renderTaskDigestList_(upcoming));
+    }
+    const html = [
+      '<div style="font-family:Roboto,Arial,sans-serif;color:#202124;">',
+      '<div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">',
+      '<img src="' + BRAND_LOGO_URL + '" alt="AuraFlow" style="height:28px;width:28px;">',
+      '<span style="font-size:20px;font-weight:600;">AuraFlow</span>',
+      '</div>',
+      '<p style="margin:0 0 12px;">Here is your ' + (mode === 'weekly' ? 'weekly' : 'daily') + ' task digest.</p>',
+      htmlSections.join(''),
+      '<p style="margin:16px 0 0;">View all tasks in AuraFlow to update progress.</p>',
+      '<p><a href="' + getAppUrl_() + '" style="color:#1a73e8;">Open AuraFlow</a></p>',
+      brandFooterHtml_(),
+      '</div>'
+    ].join('');
+    try {
+      MailApp.sendEmail({
+        to: user.notificationEmail || user.email,
+        subject: '[AuraFlow] ' + (mode === 'weekly' ? 'Weekly' : 'Daily') + ' Digest',
+        htmlBody: html,
+        body: 'Open AuraFlow to review your tasks: ' + getAppUrl_(),
+        name: 'AuraFlow'
+      });
+    } catch (err) {
+      Logger.log('Digest email failed for ' + user.email + ': ' + err);
+    }
+  });
+}
+
+function renderTaskDigestList_(tasks) {
+  if (!tasks.length) {
+    return '<p>No tasks.</p>';
+  }
+  const items = tasks.slice(0, 20).map(function (task) {
+    return '<li style="margin-bottom:6px;">' +
+      '<strong>' + sanitizeHtml_(task.title) + '</strong>' +
+      (task.dueDate ? ' &mdash; due ' + task.dueDate : '') +
+      ' <span style="color:#5f6368;">(' + task.status + ')</span>' +
+      '</li>';
+  }).join('');
+  return '<ul style="padding-left:20px;margin:0;">' + items + '</ul>';
+}
+
+function appendRecord_(sheet, headers, record) {
+  const row = headers.map(function (key) {
+    return record[key] !== undefined && record[key] !== null ? record[key] : '';
+  });
+  sheet.appendRow(row);
+  return sheet.getLastRow();
+}
+
+function writeRecord_(sheet, headers, rowNumber, record) {
+  const row = headers.map(function (key) {
+    return record[key] !== undefined && record[key] !== null ? record[key] : '';
+  });
+  sheet.getRange(rowNumber, 1, 1, headers.length).setValues([row]);
+}
+
+function loadTable_(sheet, headers) {
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    return [];
+  }
+  const values = sheet.getRange(2, 1, lastRow - 1, headers.length).getValues();
+  return values.map(function (row, index) {
+    const record = {};
+    headers.forEach(function (header, col) {
+      record[header] = row[col];
+    });
+    return { rowNumber: index + 2, record: record };
+  });
+}
+
+function sanitizeTask_(record) {
+  return {
+    id: record.id || '',
+    title: record.title || '',
+    description: record.description || '',
+    assignedTo: (record.assignedTo || '').trim(),
+    priority: PRIORITIES.indexOf(record.priority) >= 0 ? record.priority : 'Normal',
+    status: STATUSES.indexOf(record.status) >= 0 ? record.status : 'Todo',
+    dueDate: record.dueDate || '',
+    estimatedHours: Number(record.estimatedHours) || 0,
+    tags: record.tags || '',
+    links: record.links || '',
+    createdBy: record.createdBy || '',
+    createdAt: record.createdAt || '',
+    updatedAt: record.updatedAt || '',
+    totalSeconds: Number(record.totalSeconds) || 0
+  };
+}
+
+function sanitizeTool_(record) {
+  return {
+    id: record.id || '',
+    iconUrl: record.iconUrl || BRAND_LOGO_URL,
+    name: record.name || '',
+    toolUrl: record.toolUrl || '',
+    isActive: toBool_(record.isActive),
+    createdAt: record.createdAt || '',
+    updatedAt: record.updatedAt || '',
+    sortOrder: Number(record.sortOrder) || 0
+  };
+}
+
+function computeTaskTotals_(tasks, email) {
+  const totals = {
+    count: tasks.length,
+    byStatus: {
+      Todo: 0,
+      Doing: 0,
+      Done: 0,
+      Blocked: 0
+    },
+    totalEstimatedHours: 0,
+    totalSeconds: 0,
+    mySeconds: 0
+  };
+  const lowerEmail = (email || '').toLowerCase();
+  tasks.forEach(function (task) {
+    if (totals.byStatus[task.status] !== undefined) {
+      totals.byStatus[task.status] += 1;
+    }
+    totals.totalEstimatedHours += Number(task.estimatedHours) || 0;
+    totals.totalSeconds += Number(task.totalSeconds) || 0;
+    if (task.assignedTo && task.assignedTo.toLowerCase() === lowerEmail) {
+      totals.mySeconds += Number(task.totalSeconds) || 0;
+    }
+  });
+  return totals;
+}
+
+function buildVisibilityEmails_(viewer, users) {
+  const my = viewer.email ? [viewer.email.toLowerCase()] : [];
+  let team = [];
+  let all = [];
+  if (isRoleAtLeast_(viewer.role, 'ADMIN')) {
+    all = users.filter(function (u) { return u.isActive; }).map(function (u) { return u.email.toLowerCase(); });
+    team = all.filter(function (email) { return my.indexOf(email) === -1; });
+  } else if (viewer.role === 'MANAGER') {
+    team = users.filter(function (u) { return u.isActive && u.parentUserId === viewer.id; }).map(function (u) { return u.email.toLowerCase(); });
+    all = dedupeArray_(my.concat(team));
+  } else {
+    all = my.slice();
+  }
+  return {
+    my: dedupeArray_(my),
+    team: dedupeArray_(team),
+    all: dedupeArray_(all.length ? all : my)
+  };
+}
+
+function addDays_(isoDate, days) {
+  if (!isoDate) {
+    return '';
+  }
+  const date = new Date(isoDate + 'T00:00:00');
+  date.setDate(date.getDate() + days);
+  return Utilities.formatDate(date, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+}
+
+function normalizeDate_(value) {
+  if (!value) {
+    return '';
+  }
+  if (Object.prototype.toString.call(value) === '[object Date]') {
+    return Utilities.formatDate(value, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return trimmed;
+    }
+    const parsed = new Date(trimmed);
+    if (!isNaN(parsed.getTime())) {
+      return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    }
+  }
+  return '';
+}
+
+function canInteractWithTask_(viewer, taskRecord, usersTable) {
+  if (isRoleAtLeast_(viewer.role, 'ADMIN')) {
+    return true;
+  }
+  const users = usersTable.map(function (entry) {
+    return sanitizeUser_(entry.record);
+  });
+  const visibility = buildVisibilityEmails_(viewer, users);
+  const assigned = (taskRecord.assignedTo || '').toLowerCase();
+  return assigned && visibility.all.indexOf(assigned) !== -1;
+}
+
+function accumulateTaskTime_(env, taskId) {
+  const timeSheet = env.sheets.TimeLog.sheet;
+  const timeHeaders = SHEET_DEFINITIONS.TimeLog.headers;
+  const logs = loadTable_(timeSheet, timeHeaders).filter(function (row) {
+    return row.record.taskId === taskId;
+  });
+  const total = logs.reduce(function (sum, row) {
+    return sum + (Number(row.record.durationSeconds) || 0);
+  }, 0);
+  const taskSheet = env.sheets.Tasks.sheet;
+  const taskHeaders = SHEET_DEFINITIONS.Tasks.headers;
+  const tasks = loadTable_(taskSheet, taskHeaders);
+  const entry = tasks.find(function (row) {
+    return row.record.id === taskId;
+  });
+  if (entry) {
+    entry.record.totalSeconds = total;
+    entry.record.updatedAt = todayISO_();
+    writeRecord_(taskSheet, taskHeaders, entry.rowNumber, entry.record);
+  }
+}
+
+function toBool_(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return value.toUpperCase() === 'TRUE';
+  }
+  return !!value;
+}
+
+function getNotificationPrefs_(userId) {
+  if (!userId) {
+    return { instant: true, daily: true, weekly: true };
+  }
+  const props = PropertiesService.getScriptProperties();
+  const raw = props.getProperty('notify_' + userId);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      return {
+        instant: parsed.instant !== false,
+        daily: parsed.daily !== false,
+        weekly: parsed.weekly !== false
+      };
+    } catch (err) {
+      return { instant: true, daily: true, weekly: true };
+    }
+  }
+  return { instant: true, daily: true, weekly: true };
+}
+
+function saveNotificationPrefs_(userId, prefs) {
+  if (!userId) {
+    return;
+  }
+  const merged = {
+    instant: prefs.instant !== false,
+    daily: prefs.daily !== false,
+    weekly: prefs.weekly !== false
+  };
+  PropertiesService.getScriptProperties().setProperty('notify_' + userId, JSON.stringify(merged));
+}
+
+function dedupeArray_(list) {
+  const seen = {};
+  return (list || []).filter(function (item) {
+    const key = String(item).toLowerCase();
+    if (seen[key]) {
+      return false;
+    }
+    seen[key] = true;
+    return true;
+  });
+}
+
+function sanitizeHtml_(text) {
+  return String(text || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function brandFooterHtml_() {
+  return '<div style="margin-top:24px;font-size:12px;color:#5f6368;line-height:1.4;">' +
+    'AuraFlow by Aura One Labs<br>' +
+    '<span style="display:inline-flex;align-items:center;gap:4px;">' +
+    '<img src="' + BRAND_LOGO_URL + '" alt="AuraFlow" style="height:14px;width:14px;">' +
+    'Rare Aura Media Group</span>' +
+    '</div>';
+}
+
+function getAppUrl_() {
+  try {
+    const url = ScriptApp.getService().getUrl();
+    if (url) {
+      return url;
+    }
+  } catch (err) {
+    Logger.log('App URL unavailable: ' + err);
+  }
+  return 'https://script.google.com/macros/s/' + ScriptApp.getScriptId() + '/exec';
+}
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1440 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>AuraFlow</title>
+    <base target="_top">
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: 'Inter', 'Segoe UI', Roboto, Arial, sans-serif;
+        background: #f5f7fb;
+        color: #202124;
+      }
+      #app {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      .app-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 24px;
+        background: #ffffff;
+        border-bottom: 1px solid #e0e3eb;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 22px;
+        font-weight: 600;
+        color: #1f2933;
+      }
+      .brand img {
+        width: 32px;
+        height: 32px;
+      }
+      .session-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+        color: #5f6368;
+      }
+      .session-info strong {
+        color: #1f2933;
+      }
+      .tab-bar {
+        display: flex;
+        gap: 4px;
+        padding: 12px 24px 0;
+        flex-wrap: wrap;
+        background: #ffffff;
+        border-bottom: 1px solid #e0e3eb;
+      }
+      .tab-button {
+        border: none;
+        background: #edf1fb;
+        color: #3a4753;
+        border-radius: 999px;
+        padding: 8px 18px;
+        font-size: 14px;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+      .tab-button.active {
+        background: #1a73e8;
+        color: #ffffff;
+        box-shadow: 0 4px 12px rgba(26, 115, 232, 0.25);
+      }
+      main {
+        flex: 1;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+      .tab-pane {
+        display: none;
+      }
+      .tab-pane.active {
+        display: block;
+      }
+      .grid {
+        display: grid;
+        gap: 16px;
+      }
+      .grid.cards {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .card {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 20px;
+        box-shadow: 0 10px 30px rgba(15, 35, 95, 0.08);
+        border: 1px solid rgba(142, 159, 189, 0.16);
+      }
+      .card h3 {
+        margin: 0 0 4px;
+        font-size: 16px;
+        color: #1f2933;
+      }
+      .card p {
+        margin: 4px 0 0;
+        color: #5f6368;
+        font-size: 13px;
+      }
+      .status-message {
+        margin: 16px 24px 0;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: #fff3cd;
+        color: #8c6d1f;
+        border: 1px solid #ffe8a1;
+      }
+      .status-message.error {
+        background: #fde7e9;
+        border-color: #f7c5c9;
+        color: #a1262d;
+      }
+      .status-message.hidden {
+        display: none;
+      }
+      .task-controls {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+      .chip-group,
+      .filter-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .chip {
+        border: none;
+        padding: 6px 14px;
+        border-radius: 999px;
+        background: #e8eefc;
+        color: #3a4753;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      .chip.active {
+        background: #1a73e8;
+        color: #ffffff;
+        box-shadow: 0 6px 16px rgba(26, 115, 232, 0.25);
+      }
+      .chip.toggle {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .search-input {
+        position: relative;
+        flex: 1;
+        min-width: 220px;
+      }
+      .search-input input {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid #ccd4e0;
+        background: #ffffff;
+      }
+      .select {
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid #ccd4e0;
+        background: #ffffff;
+      }
+      .task-list {
+        display: grid;
+        gap: 16px;
+      }
+      .task-card {
+        background: #ffffff;
+        border-radius: 14px;
+        padding: 18px;
+        border-left: 6px solid transparent;
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.07);
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .task-card.high {
+        border-left-color: #f87171;
+      }
+      .task-card.normal {
+        border-left-color: #60a5fa;
+      }
+      .task-card.low {
+        border-left-color: #34d399;
+      }
+      .task-card.done {
+        opacity: 0.75;
+      }
+      .task-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+      }
+      .task-title {
+        font-size: 16px;
+        font-weight: 600;
+        color: #1f2933;
+      }
+      .badge {
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .badge.priority-high {
+        background: rgba(248, 113, 113, 0.15);
+        color: #b91c1c;
+      }
+      .badge.priority-low {
+        background: rgba(16, 185, 129, 0.18);
+        color: #047857;
+      }
+      .badge.priority-normal {
+        background: rgba(96, 165, 250, 0.18);
+        color: #1d4ed8;
+      }
+      .badge.status-todo {
+        background: rgba(148, 163, 184, 0.28);
+        color: #1f2933;
+      }
+      .badge.status-doing {
+        background: rgba(96, 165, 250, 0.25);
+        color: #1d4ed8;
+      }
+      .badge.status-blocked {
+        background: rgba(251, 191, 36, 0.32);
+        color: #b45309;
+      }
+      .badge.status-done {
+        background: rgba(16, 185, 129, 0.24);
+        color: #047857;
+      }
+      .task-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        font-size: 12px;
+        color: #5f6368;
+      }
+      .task-desc {
+        font-size: 13px;
+        color: #3a4753;
+        margin: 0;
+        white-space: pre-wrap;
+      }
+      .task-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      button.primary {
+        background: #1a73e8;
+        color: #ffffff;
+        border: none;
+        border-radius: 10px;
+        padding: 8px 16px;
+        cursor: pointer;
+        font-size: 13px;
+        transition: transform 0.2s ease;
+      }
+      button.primary:hover {
+        transform: translateY(-1px);
+      }
+      button.ghost {
+        border: 1px solid #ccd4e0;
+        background: #ffffff;
+        color: #1f2933;
+        border-radius: 10px;
+        padding: 8px 14px;
+        cursor: pointer;
+      }
+      button.danger {
+        border: none;
+        background: #dc2626;
+        color: #ffffff;
+        border-radius: 10px;
+        padding: 8px 14px;
+        cursor: pointer;
+      }
+      form.inline {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+      }
+      form.inline input,
+      form.inline textarea,
+      form.inline select {
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid #ccd4e0;
+        background: #ffffff;
+        font-size: 14px;
+      }
+      form.inline textarea {
+        min-width: 240px;
+        min-height: 80px;
+      }
+      .section-title {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0 0 12px;
+        color: #1f2933;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #ffffff;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+      }
+      th, td {
+        padding: 12px 16px;
+        text-align: left;
+        font-size: 13px;
+        border-bottom: 1px solid #eef1f6;
+      }
+      th {
+        background: #f8fafc;
+        color: #3a4753;
+        font-weight: 600;
+      }
+      tr:last-child td {
+        border-bottom: none;
+      }
+      .tools-grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .tool-card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: flex-start;
+      }
+      .tool-card img {
+        width: 36px;
+        height: 36px;
+        border-radius: 10px;
+        background: #f1f5f9;
+        object-fit: contain;
+      }
+      .tool-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      details summary {
+        cursor: pointer;
+        font-weight: 600;
+        color: #1a73e8;
+      }
+      .app-footer {
+        background: #f1f3f4;
+        text-align: center;
+        padding: 16px;
+        font-size: 12px;
+        color: #5f6368;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        align-items: center;
+      }
+      .app-footer img {
+        width: 16px;
+        height: 16px;
+        vertical-align: middle;
+        margin-right: 6px;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        right: 24px;
+        background: #1a73e8;
+        color: #ffffff;
+        padding: 14px 18px;
+        border-radius: 12px;
+        box-shadow: 0 20px 40px rgba(26, 115, 232, 0.35);
+        opacity: 0;
+        transform: translateY(12px);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        z-index: 999;
+      }
+      .toast.visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      .hidden {
+        display: none !important;
+      }
+      .spinner {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 4px solid rgba(26, 115, 232, 0.25);
+        border-top-color: #1a73e8;
+        animation: spin 1s linear infinite;
+        margin: 24px auto;
+      }
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+      @media (max-width: 768px) {
+        .app-header {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 12px;
+        }
+        .session-info {
+          align-self: stretch;
+          justify-content: space-between;
+        }
+        .task-head {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .task-actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <header class="app-header">
+        <div class="brand">
+          <img src="https://images.emojiterra.com/google/noto-emoji/unicode-16.0/color/svg/1f300.svg" alt="AuraFlow logo">
+          <span>AuraFlow</span>
+        </div>
+        <div class="session-info">
+          <span id="userBadge">Connecting…</span>
+          <button id="adminQuickAdd" class="ghost hidden">Add current Google account</button>
+        </div>
+      </header>
+      <div id="statusMessage" class="status-message hidden"></div>
+      <nav class="tab-bar">
+        <button class="tab-button active" data-tab="dashboard">Dashboard</button>
+        <button class="tab-button" data-tab="tasks">Tasks</button>
+        <button class="tab-button" data-tab="users">Users</button>
+        <button class="tab-button" data-tab="tools">Tools</button>
+        <button class="tab-button" data-tab="settings">Settings / Help</button>
+      </nav>
+      <main>
+        <section id="tab-dashboard" class="tab-pane active">
+          <h2 class="section-title">Team pulse</h2>
+          <div id="dashboardContent" class="grid cards"></div>
+        </section>
+        <section id="tab-tasks" class="tab-pane">
+          <div class="task-controls">
+            <div class="chip-group" id="viewChips">
+              <button class="chip active" data-view="my">My</button>
+              <button class="chip" data-view="team">Team</button>
+              <button class="chip" data-view="all">All</button>
+              <button class="chip toggle" id="toggleCompleted">👁 Show Completed</button>
+              <button class="chip toggle" id="toggleOverdue">⚠️ Overdue Only</button>
+            </div>
+            <div class="chip-group" id="statusChips">
+              <button class="chip" data-status="Todo">Todo</button>
+              <button class="chip" data-status="Doing">Doing</button>
+              <button class="chip" data-status="Blocked">Blocked</button>
+              <button class="chip" data-status="Done">Done</button>
+            </div>
+            <div class="filter-row">
+              <div class="search-input">
+                <input type="search" id="taskSearch" placeholder="Search tasks, tags, assignees…">
+              </div>
+              <select id="sortSelect" class="select">
+                <option value="dueDate|asc">Sort by Due Date ↑</option>
+                <option value="dueDate|desc">Sort by Due Date ↓</option>
+                <option value="priority|asc">Priority ↑</option>
+                <option value="priority|desc">Priority ↓</option>
+                <option value="status|asc">Status ↑</option>
+                <option value="status|desc">Status ↓</option>
+              </select>
+              <button id="exportTasks" class="ghost">⬇️ Export CSV</button>
+            </div>
+          </div>
+          <div class="card" style="margin-bottom:16px;">
+            <h3>Quick add</h3>
+            <form id="quickTaskForm" class="inline">
+              <input type="text" name="title" placeholder="Task title" required>
+              <input type="email" name="assignedTo" placeholder="Assignee email" required>
+              <input type="date" name="dueDate" placeholder="Due date">
+              <button type="submit" class="primary">Add</button>
+            </form>
+            <details style="margin-top:12px;">
+              <summary>Full task composer</summary>
+              <form id="taskForm" class="inline" style="margin-top:12px;">
+                <input type="hidden" name="id">
+                <input type="text" name="title" placeholder="Task title" required>
+                <textarea name="description" placeholder="Description"></textarea>
+                <input type="email" name="assignedTo" placeholder="Assignee email" required>
+                <select name="priority">
+                  <option value="Normal">Priority: Normal</option>
+                  <option value="High">Priority: High</option>
+                  <option value="Low">Priority: Low</option>
+                </select>
+                <select name="status">
+                  <option value="Todo">Status: Todo</option>
+                  <option value="Doing">Status: Doing</option>
+                  <option value="Blocked">Status: Blocked</option>
+                  <option value="Done">Status: Done</option>
+                </select>
+                <input type="date" name="dueDate">
+                <input type="number" min="0" step="0.25" name="estimatedHours" placeholder="Estimated hours">
+                <input type="text" name="tags" placeholder="Tags (comma separated)">
+                <input type="url" name="links" placeholder="Reference links">
+                <div style="display:flex;gap:8px;">
+                  <button type="submit" class="primary" id="taskFormSubmit">Save task</button>
+                  <button type="button" class="ghost hidden" id="taskFormCancel">Cancel edit</button>
+                </div>
+              </form>
+            </details>
+          </div>
+          <div id="taskSummary" class="grid cards" style="margin-bottom:16px;"></div>
+          <div id="taskList" class="task-list"></div>
+          <div id="taskLoader" class="spinner hidden"></div>
+          <button id="loadMoreTasks" class="ghost hidden">Load more</button>
+        </section>
+        <section id="tab-users" class="tab-pane">
+          <div class="card" style="margin-bottom:16px;">
+            <h3>Invite a teammate</h3>
+            <form id="userForm" class="inline">
+              <input type="text" name="firstName" placeholder="First name" required>
+              <input type="text" name="lastName" placeholder="Last name">
+              <input type="email" name="email" placeholder="Work email" required>
+              <input type="email" name="notificationEmail" placeholder="Notification email" required>
+              <select name="role" required>
+                <option value="USER">User</option>
+                <option value="MANAGER">Manager</option>
+                <option value="ADMIN">Admin</option>
+                <option value="MASTER_ADMIN">Master Admin</option>
+              </select>
+              <button type="submit" class="primary">Create user</button>
+            </form>
+          </div>
+          <div class="card" style="margin-bottom:16px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+              <h3>Directory</h3>
+              <button id="refreshUsers" class="ghost">Refresh</button>
+            </div>
+            <div class="table-wrapper">
+              <table id="usersTable">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Role</th>
+                    <th>Status</th>
+                    <th>Notification</th>
+                    <th>Updated</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+        <section id="tab-tools" class="tab-pane">
+          <div class="card" id="toolFormCard" style="margin-bottom:16px;">
+            <h3>Tool catalog</h3>
+            <form id="toolForm" class="inline">
+              <input type="hidden" name="id">
+              <input type="url" name="iconUrl" placeholder="Icon URL">
+              <input type="text" name="name" placeholder="Tool name" required>
+              <input type="url" name="toolUrl" placeholder="https://" required>
+              <input type="number" step="1" name="sortOrder" placeholder="Sort order">
+              <label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+                <input type="checkbox" name="isActive" checked> Active
+              </label>
+              <div style="display:flex;gap:8px;">
+                <button type="submit" class="primary" id="toolSubmit">Save tool</button>
+                <button type="button" class="ghost hidden" id="toolCancel">Cancel edit</button>
+              </div>
+            </form>
+          </div>
+          <div id="toolsList" class="tools-grid"></div>
+        </section>
+        <section id="tab-settings" class="tab-pane">
+          <div class="grid" style="gap:16px;">
+            <div class="card">
+              <h3>Notifications</h3>
+              <form id="settingsForm" class="inline">
+                <input type="email" name="notificationEmail" placeholder="Notification email">
+                <label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+                  <input type="checkbox" name="instant" checked> Instant assignment alerts
+                </label>
+                <label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+                  <input type="checkbox" name="daily" checked> Daily digest
+                </label>
+                <label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+                  <input type="checkbox" name="weekly" checked> Weekly digest
+                </label>
+                <div style="display:flex;gap:8px;">
+                  <button type="submit" class="primary">Save settings</button>
+                  <button type="button" id="sendTestEmail" class="ghost">Send test email</button>
+                </div>
+              </form>
+            </div>
+            <div class="card">
+              <h3>Tutorial</h3>
+              <ol style="margin:0;padding-left:20px;color:#3a4753;font-size:13px;line-height:1.6;">
+                <li>Review dashboard highlights</li>
+                <li>Explore your tasks and apply filters</li>
+                <li>Confirm notification email settings</li>
+              </ol>
+              <button id="completeTutorial" class="primary" style="margin-top:12px;">Mark tutorial complete</button>
+            </div>
+            <div class="card">
+              <h3>Help &amp; resources</h3>
+              <details open>
+                <summary>Quick start</summary>
+                <p>Use the Tasks tab to capture work, assign teammates, and track progress. Filters keep focus tight.</p>
+              </details>
+              <details>
+                <summary>CSV import template</summary>
+                <p>Download a ready template, fill task rows, and upload via the Tasks tab import action.</p>
+                <button id="downloadTemplate" class="ghost" style="margin-top:8px;">Download template</button>
+              </details>
+              <details>
+                <summary>Role visibility</summary>
+                <p><strong>Admins</strong> see everything. <strong>Managers</strong> see their direct team. <strong>Users</strong> see tasks assigned to them.</p>
+              </details>
+              <details>
+                <summary>Email delivery</summary>
+                <p>Assignment alerts are instant. Digests send daily at 6:00 PM IST and weekly on Sundays at 10:00 AM IST.</p>
+              </details>
+              <details>
+                <summary>Google Sign-In</summary>
+                <p>AuraFlow respects your Google account. Stay signed in with the correct profile before opening the app.</p>
+              </details>
+            </div>
+          </div>
+        </section>
+      </main>
+      <footer class="app-footer">
+        <div>AuraFlow by Aura One Labs</div>
+        <div><img src="https://images.emojiterra.com/google/noto-emoji/unicode-16.0/color/svg/1f300.svg" alt="AuraFlow swirl">Rare Aura Media Group</div>
+      </footer>
+    </div>
+    <div id="toast" class="toast hidden"></div>
+    <script>
+      const LOGO_URL = 'https://images.emojiterra.com/google/noto-emoji/unicode-16.0/color/svg/1f300.svg';
+      const ROLE_ORDER = ['MASTER_ADMIN', 'ADMIN', 'MANAGER', 'USER'];
+      const appState = {
+        env: null,
+        session: null,
+        activeTab: 'dashboard',
+        loadedTabs: { dashboard: false, tasks: false, users: false, tools: false, settings: false },
+        tasks: {
+          filters: {
+            view: 'my',
+            includeDone: false,
+            statusFilters: [],
+            overdueOnly: false,
+            q: '',
+            sortBy: 'dueDate',
+            sortDir: 'asc'
+          },
+          rows: [],
+          nextPageToken: '',
+          totals: null,
+          activeTimer: null
+        },
+        users: [],
+        tools: [],
+        debounceHandles: {}
+      };
+
+      document.addEventListener('DOMContentLoaded', () => {
+        setupEventListeners();
+        bootstrap();
+      });
+
+      function bootstrap() {
+        setStatus('Validating workspace…');
+        google.script.run
+          .withSuccessHandler(handleEnv)
+          .withFailureHandler(err => handleError('Unable to reach AuraFlow. ' + err.message))
+          .getEnv_();
+      }
+
+      function handleEnv(res) {
+        if (!res || !res.success) {
+          handleError('Spreadsheet configuration missing. Ask an admin to set SPREADSHEET_ID in Code.gs.');
+          return;
+        }
+        appState.env = res.data;
+        fetchSession();
+      }
+
+      function fetchSession() {
+        setStatus('Signing you in…');
+        google.script.run
+          .withSuccessHandler(res => {
+            if (!res || !res.success) {
+              const message = (res && res.message) || 'ACCESS_DENIED';
+              if (message === 'GOOGLE_SIGN_IN_REQUIRED') {
+                handleError('Sign in to Google with an authorized account and reopen AuraFlow.');
+                return;
+              }
+              if (message === 'ACCESS_DENIED') {
+                handleError('Access denied. Ask an AuraFlow admin to add your Google account in the Users tab.');
+                return;
+              }
+              handleError(message);
+              return;
+            }
+            clearStatus();
+            appState.session = res.data;
+            updateHeader();
+            setupAdminUtilities();
+            switchTab('dashboard', true);
+          })
+          .withFailureHandler(err => handleError('Authentication failed: ' + err.message))
+          .currentSession();
+      }
+
+      function setupEventListeners() {
+        document.querySelectorAll('.tab-button').forEach(btn => {
+          btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+        });
+        document.getElementById('quickTaskForm').addEventListener('submit', handleQuickTaskSubmit);
+        document.getElementById('taskForm').addEventListener('submit', handleTaskFormSubmit);
+        document.getElementById('taskFormCancel').addEventListener('click', resetTaskForm);
+        document.getElementById('taskSearch').addEventListener('input', handleTaskSearch);
+        document.getElementById('sortSelect').addEventListener('change', handleSortChange);
+        document.getElementById('toggleCompleted').addEventListener('click', toggleCompleted);
+        document.getElementById('toggleOverdue').addEventListener('click', toggleOverdue);
+        document.getElementById('loadMoreTasks').addEventListener('click', () => loadTasks(false));
+        document.getElementById('taskList').addEventListener('click', handleTaskListAction);
+        document.getElementById('statusChips').addEventListener('click', handleStatusChip);
+        document.getElementById('viewChips').addEventListener('click', handleViewChip);
+        document.getElementById('exportTasks').addEventListener('click', exportTasks);
+        document.getElementById('userForm').addEventListener('submit', handleUserSubmit);
+        document.getElementById('refreshUsers').addEventListener('click', loadUsers);
+        document.getElementById('toolForm').addEventListener('submit', handleToolSubmit);
+        document.getElementById('toolCancel').addEventListener('click', resetToolForm);
+        document.getElementById('settingsForm').addEventListener('submit', handleSettingsSubmit);
+        document.getElementById('sendTestEmail').addEventListener('click', sendTestEmail);
+        document.getElementById('completeTutorial').addEventListener('click', markTutorialComplete);
+        document.getElementById('downloadTemplate').addEventListener('click', downloadTemplate);
+      }
+
+      function updateHeader() {
+        const badge = document.getElementById('userBadge');
+        const user = appState.session.user;
+        badge.textContent = user ? `${user.email} · ${user.role.replace('_', ' ')}` : 'Unknown user';
+      }
+
+      function setupAdminUtilities() {
+        const adminBtn = document.getElementById('adminQuickAdd');
+        if (isRoleAtLeast(appState.session.user.role, 'ADMIN')) {
+          adminBtn.classList.remove('hidden');
+          adminBtn.addEventListener('click', () => {
+            adminBtn.disabled = true;
+            google.script.run
+              .withSuccessHandler(res => {
+                adminBtn.disabled = false;
+                if (res && res.success) {
+                  showToast('Account registered. Refreshing users.');
+                  loadUsers();
+                } else {
+                  handleError((res && res.message) || 'Unable to add account');
+                }
+              })
+              .withFailureHandler(err => {
+                adminBtn.disabled = false;
+                handleError(err.message);
+              })
+              .adminQuickAddSelf({
+                role: appState.session.user.role,
+                firstName: '',
+                lastName: '',
+                notificationEmail: appState.session.user.email
+              });
+          }, { once: true });
+        }
+      }
+
+      function switchTab(tab, forceReload = false) {
+        if (appState.activeTab === tab && !forceReload) {
+          return;
+        }
+        document.querySelectorAll('.tab-button').forEach(btn => {
+          btn.classList.toggle('active', btn.dataset.tab === tab);
+        });
+        document.querySelectorAll('.tab-pane').forEach(pane => {
+          pane.classList.toggle('active', pane.id === `tab-${tab}`);
+        });
+        appState.activeTab = tab;
+        if (!appState.loadedTabs[tab] || forceReload) {
+          if (tab === 'dashboard') {
+            loadDashboard();
+          } else if (tab === 'tasks') {
+            loadTasks(true);
+          } else if (tab === 'users') {
+            loadUsers();
+          } else if (tab === 'tools') {
+            loadTools();
+          } else if (tab === 'settings') {
+            populateSettings();
+          }
+          appState.loadedTabs[tab] = true;
+        }
+      }
+
+      function setStatus(message, isError = false) {
+        const status = document.getElementById('statusMessage');
+        status.textContent = message;
+        status.classList.toggle('hidden', !message);
+        status.classList.toggle('error', isError);
+      }
+
+      function clearStatus() {
+        setStatus('');
+      }
+
+      function handleError(message) {
+        setStatus(message, true);
+        showToast(message, true);
+      }
+
+      function showToast(message, isError = false) {
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.style.background = isError ? '#d93025' : '#1a73e8';
+        toast.classList.remove('hidden');
+        requestAnimationFrame(() => toast.classList.add('visible'));
+        clearTimeout(appState.debounceHandles.toast);
+        appState.debounceHandles.toast = setTimeout(() => {
+          toast.classList.remove('visible');
+          setTimeout(() => toast.classList.add('hidden'), 300);
+        }, 3500);
+      }
+
+      function isRoleAtLeast(role, minimum) {
+        return ROLE_ORDER.indexOf(role) <= ROLE_ORDER.indexOf(minimum);
+      }
+
+      function escapeHtml(text) {
+        return String(text || '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+      function loadDashboard() {
+        const container = document.getElementById('dashboardContent');
+        container.innerHTML = '<div class="spinner"></div>';
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              renderDashboard(res.data);
+            } else {
+              container.innerHTML = `<p>${(res && res.message) || 'Unable to load metrics.'}</p>`;
+            }
+          })
+          .withFailureHandler(err => {
+            container.innerHTML = `<p>${err.message}</p>`;
+          })
+          .getDashboardMetrics();
+      }
+
+      function renderDashboard(data) {
+        const container = document.getElementById('dashboardContent');
+        if (!data) {
+          container.innerHTML = '<p>No metrics available.</p>';
+          return;
+        }
+        container.innerHTML = `
+          <div class="card">
+            <h3>Total tasks</h3>
+            <p style="font-size:28px;font-weight:700;">${data.total || 0}</p>
+            <p>${data.dueSoon || 0} due soon · ${data.overdue || 0} overdue</p>
+          </div>
+          <div class="card">
+            <h3>Status spread</h3>
+            <p>Todo: ${data.byStatus.Todo || 0}</p>
+            <p>Doing: ${data.byStatus.Doing || 0}</p>
+            <p>Blocked: ${data.byStatus.Blocked || 0}</p>
+            <p>Done: ${data.byStatus.Done || 0}</p>
+          </div>
+          <div class="card">
+            <h3>My focus</h3>
+            <p style="font-size:24px;font-weight:600;">${data.myTotals.count || 0} tasks</p>
+            <p>Time tracked: ${(data.myTotals.mySeconds / 3600 || 0).toFixed(1)} hrs</p>
+          </div>
+          <div class="card">
+            <h3>Team time</h3>
+            <p style="font-size:24px;font-weight:600;">${(data.teamTotals.totalSeconds / 3600 || 0).toFixed(1)} hrs logged</p>
+            <p>Estimates: ${(data.teamTotals.totalEstimatedHours || 0).toFixed(1)} hrs</p>
+          </div>
+        `;
+      }
+
+      function loadTasks(reset = false) {
+        if (reset) {
+          appState.tasks.rows = [];
+          appState.tasks.nextPageToken = '';
+          renderTasks();
+        }
+        const loader = document.getElementById('taskLoader');
+        loader.classList.remove('hidden');
+        const filters = appState.tasks.filters;
+        const payload = {
+          view: filters.view,
+          includeDone: filters.includeDone,
+          statusFilters: filters.statusFilters,
+          overdueOnly: filters.overdueOnly,
+          q: filters.q,
+          sortBy: filters.sortBy,
+          sortDir: filters.sortDir,
+          pageToken: reset ? '0' : appState.tasks.rows.length.toString(),
+          pageSize: 50
+        };
+        google.script.run
+          .withSuccessHandler(res => {
+            loader.classList.add('hidden');
+            if (res && res.success) {
+              const incoming = res.data.rows || [];
+              appState.tasks.rows = reset ? incoming : appState.tasks.rows.concat(incoming);
+              appState.tasks.nextPageToken = res.data.nextPageToken || '';
+              appState.tasks.totals = res.data.totals || null;
+              renderTasks();
+            } else {
+              handleError((res && res.message) || 'Unable to load tasks');
+            }
+          })
+          .withFailureHandler(err => {
+            loader.classList.add('hidden');
+            handleError(err.message);
+          })
+          .getTasks(payload);
+      }
+
+      function renderTasks() {
+        const list = document.getElementById('taskList');
+        const summary = document.getElementById('taskSummary');
+        const totals = appState.tasks.totals;
+        if (totals) {
+          summary.innerHTML = `
+            <div class="card"><h3>Visible tasks</h3><p style="font-size:24px;font-weight:600;">${totals.count || 0}</p></div>
+            <div class="card"><h3>Todo</h3><p>${totals.byStatus ? totals.byStatus.Todo || 0 : 0}</p></div>
+            <div class="card"><h3>Doing</h3><p>${totals.byStatus ? totals.byStatus.Doing || 0 : 0}</p></div>
+            <div class="card"><h3>Blocked</h3><p>${totals.byStatus ? totals.byStatus.Blocked || 0 : 0}</p></div>
+          `;
+        } else {
+          summary.innerHTML = '';
+        }
+        if (!appState.tasks.rows.length) {
+          list.innerHTML = '<div class="card"><p>No tasks match the current filters.</p></div>';
+        } else {
+          list.innerHTML = appState.tasks.rows.map(renderTaskCard).join('');
+        }
+        document.getElementById('loadMoreTasks').classList.toggle('hidden', !appState.tasks.nextPageToken);
+      }
+
+      function renderTaskCard(task) {
+        const priorityClass = (task.priority || 'Normal').toLowerCase();
+        const statusClass = (task.status || 'Todo').toLowerCase();
+        const due = task.dueDate ? `<span>📅 ${task.dueDate}</span>` : '';
+        const tags = task.tags ? task.tags.split(',').map(t => t.trim()).filter(Boolean).map(t => `<span class="badge">#${escapeHtml(t)}</span>`).join(' ') : '';
+        const timerActive = appState.tasks.activeTimer && appState.tasks.activeTimer.taskId === task.id;
+        return `
+          <article class="task-card ${priorityClass} ${statusClass} ${task.status === 'Done' ? 'done' : ''}" data-id="${task.id}">
+            <div class="task-head">
+              <div class="task-title">${escapeHtml(task.title)}</div>
+              <div>
+                <span class="badge priority-${priorityClass}">${task.priority}</span>
+                <span class="badge status-${statusClass}">${task.status}</span>
+              </div>
+            </div>
+            <div class="task-meta">
+              ${due}
+              <span>👤 ${escapeHtml(task.assignedTo)}</span>
+              <span>⏱ ${(task.totalSeconds / 3600 || 0).toFixed(1)}h</span>
+              ${task.estimatedHours ? `<span>Estimate ${Number(task.estimatedHours).toFixed(1)}h</span>` : ''}
+            </div>
+            ${task.description ? `<p class="task-desc">${escapeHtml(task.description)}</p>` : ''}
+            ${task.links ? `<p class="task-meta">🔗 <a href="${escapeHtml(task.links)}" target="_blank" rel="noopener">Reference</a></p>` : ''}
+            ${tags ? `<div class="task-meta">${tags}</div>` : ''}
+            <div class="task-actions">
+              ${task.status !== 'Done' ? `<button class="primary" data-action="done" data-id="${task.id}">Mark done</button>` : ''}
+              <button class="ghost" data-action="edit" data-id="${task.id}">Edit</button>
+              <button class="ghost" data-action="timer" data-id="${task.id}">${timerActive ? 'Stop timer' : 'Start timer'}</button>
+            </div>
+          </article>
+        `;
+      }
+
+      function handleQuickTaskSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const payload = {
+          title: form.title.value.trim(),
+          assignedTo: form.assignedTo.value.trim(),
+          dueDate: form.dueDate.value
+        };
+        if (!payload.title || !payload.assignedTo) {
+          showToast('Title and assignee email are required.', true);
+          return;
+        }
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast('Task created.');
+              form.reset();
+              loadTasks(true);
+              loadDashboard();
+            } else {
+              handleError((res && res.message) || 'Unable to create task');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .createTask(payload);
+      }
+
+      function handleTaskFormSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const data = Object.fromEntries(new FormData(form).entries());
+        data.estimatedHours = data.estimatedHours ? Number(data.estimatedHours) : '';
+        const handler = data.id ? 'updateTask' : 'createTask';
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast(data.id ? 'Task updated.' : 'Task created.');
+              form.reset();
+              document.getElementById('taskFormCancel').classList.add('hidden');
+              loadTasks(true);
+              loadDashboard();
+            } else {
+              handleError((res && res.message) || 'Unable to save task');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          [handler](data);
+      }
+
+      function handleTaskListAction(event) {
+        const button = event.target.closest('button');
+        if (!button) return;
+        const taskId = button.dataset.id;
+        if (!taskId) return;
+        const action = button.dataset.action;
+        if (action === 'done') {
+          google.script.run
+            .withSuccessHandler(res => {
+              if (res && res.success) {
+                showToast('Task marked done.');
+                loadTasks(true);
+                loadDashboard();
+              } else {
+                handleError((res && res.message) || 'Unable to mark done');
+              }
+            })
+            .withFailureHandler(err => handleError(err.message))
+            .markDone({ taskId });
+        } else if (action === 'edit') {
+          const task = appState.tasks.rows.find(t => t.id === taskId);
+          if (task) {
+            populateTaskForm(task);
+          }
+        } else if (action === 'timer') {
+          if (appState.tasks.activeTimer && appState.tasks.activeTimer.taskId === taskId) {
+            google.script.run
+              .withSuccessHandler(res => {
+                if (res && res.success) {
+                  appState.tasks.activeTimer = null;
+                  showToast('Timer stopped.');
+                  loadTasks(true);
+                } else {
+                  handleError((res && res.message) || 'Unable to stop timer');
+                }
+              })
+              .withFailureHandler(err => handleError(err.message))
+              .stopTimer(taskId);
+          } else {
+            google.script.run
+              .withSuccessHandler(res => {
+                if (res && res.success) {
+                  appState.tasks.activeTimer = { taskId, logId: res.data ? res.data.id : null };
+                  showToast('Timer started.');
+                  renderTasks();
+                } else {
+                  handleError((res && res.message) || 'Unable to start timer');
+                }
+              })
+              .withFailureHandler(err => handleError(err.message))
+              .startTimer(taskId);
+          }
+        }
+      }
+
+      function populateTaskForm(task) {
+        const form = document.getElementById('taskForm');
+        form.id.value = task.id;
+        form.title.value = task.title;
+        form.description.value = task.description || '';
+        form.assignedTo.value = task.assignedTo;
+        form.priority.value = task.priority || 'Normal';
+        form.status.value = task.status || 'Todo';
+        form.dueDate.value = task.dueDate || '';
+        form.estimatedHours.value = task.estimatedHours || '';
+        form.tags.value = task.tags || '';
+        form.links.value = task.links || '';
+        document.getElementById('taskFormCancel').classList.remove('hidden');
+        showToast('Editing task…');
+      }
+
+      function resetTaskForm() {
+        const form = document.getElementById('taskForm');
+        form.reset();
+        form.id.value = '';
+        document.getElementById('taskFormCancel').classList.add('hidden');
+      }
+
+      function handleTaskSearch(event) {
+        clearTimeout(appState.debounceHandles.search);
+        const value = event.target.value.trim();
+        appState.debounceHandles.search = setTimeout(() => {
+          appState.tasks.filters.q = value;
+          loadTasks(true);
+        }, 300);
+      }
+
+      function handleSortChange(event) {
+        const [sortBy, sortDir] = event.target.value.split('|');
+        appState.tasks.filters.sortBy = sortBy;
+        appState.tasks.filters.sortDir = sortDir;
+        loadTasks(true);
+      }
+
+      function toggleCompleted() {
+        appState.tasks.filters.includeDone = !appState.tasks.filters.includeDone;
+        document.getElementById('toggleCompleted').classList.toggle('active', appState.tasks.filters.includeDone);
+        loadTasks(true);
+      }
+
+      function toggleOverdue() {
+        appState.tasks.filters.overdueOnly = !appState.tasks.filters.overdueOnly;
+        document.getElementById('toggleOverdue').classList.toggle('active', appState.tasks.filters.overdueOnly);
+        loadTasks(true);
+      }
+
+      function handleStatusChip(event) {
+        const chip = event.target.closest('.chip');
+        if (!chip || !chip.dataset.status) return;
+        const status = chip.dataset.status;
+        const filters = appState.tasks.filters.statusFilters;
+        if (filters.includes(status)) {
+          appState.tasks.filters.statusFilters = filters.filter(s => s !== status);
+          chip.classList.remove('active');
+        } else {
+          appState.tasks.filters.statusFilters = filters.concat(status);
+          chip.classList.add('active');
+        }
+        loadTasks(true);
+      }
+
+      function handleViewChip(event) {
+        const chip = event.target.closest('.chip');
+        if (!chip || !chip.dataset.view) return;
+        appState.tasks.filters.view = chip.dataset.view;
+        document.querySelectorAll('#viewChips .chip').forEach(btn => btn.classList.toggle('active', btn.dataset.view === chip.dataset.view));
+        loadTasks(true);
+      }
+
+      function exportTasks() {
+        if (!appState.env || !appState.env.appUrl) {
+          handleError('App URL unavailable for export.');
+          return;
+        }
+        const filters = appState.tasks.filters;
+        const params = new URLSearchParams({
+          action: 'exportTasks',
+          view: filters.view,
+          q: filters.q || '',
+          includeDone: filters.includeDone,
+          overdue: filters.overdueOnly,
+          status: filters.statusFilters.join(',')
+        });
+        window.open(`${appState.env.appUrl}?${params.toString()}`, '_blank', 'noopener');
+      }
+      function loadUsers() {
+        const tbody = document.querySelector('#usersTable tbody');
+        tbody.innerHTML = '<tr><td colspan="6">Loading…</td></tr>';
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              appState.users = res.data || [];
+              tbody.innerHTML = appState.users.map(user => `
+                <tr>
+                  <td>${escapeHtml((user.firstName || '') + ' ' + (user.lastName || '')).trim()}</td>
+                  <td>${escapeHtml(user.email)}</td>
+                  <td>${user.role}</td>
+                  <td>${user.isActive ? 'Active' : 'Inactive'}</td>
+                  <td>${escapeHtml(user.notificationEmail || '')}</td>
+                  <td>${user.updatedAt || ''}</td>
+                </tr>
+              `).join('');
+            } else {
+              tbody.innerHTML = `<tr><td colspan="6">${(res && res.message) || 'Unable to load users'}</td></tr>`;
+            }
+          })
+          .withFailureHandler(err => {
+            tbody.innerHTML = `<tr><td colspan="6">${err.message}</td></tr>`;
+          })
+          .listUsers({});
+      }
+
+      function handleUserSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const payload = Object.fromEntries(new FormData(form).entries());
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast('User created.');
+              form.reset();
+              loadUsers();
+            } else {
+              handleError((res && res.message) || 'Unable to create user');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .createUserFromUI(payload);
+      }
+
+      function loadTools() {
+        const container = document.getElementById('toolsList');
+        container.innerHTML = '<div class="spinner"></div>';
+        const params = isRoleAtLeast(appState.session.user.role, 'ADMIN') ? { includeInactive: true } : {};
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              appState.tools = res.data || [];
+              renderTools();
+            } else {
+              container.innerHTML = `<p>${(res && res.message) || 'Unable to load tools'}</p>`;
+            }
+          })
+          .withFailureHandler(err => {
+            container.innerHTML = `<p>${err.message}</p>`;
+          })
+          .listTools(params);
+      }
+
+      function renderTools() {
+        const container = document.getElementById('toolsList');
+        if (!appState.tools.length) {
+          container.innerHTML = '<div class="card"><p>No tools yet.</p></div>';
+          return;
+        }
+        container.innerHTML = appState.tools.map(tool => `
+          <div class="card tool-card" data-id="${tool.id}">
+            <img src="${escapeHtml(tool.iconUrl || LOGO_URL)}" alt="${escapeHtml(tool.name)}">
+            <h3>${escapeHtml(tool.name)}</h3>
+            <p>${tool.isActive ? 'Active' : 'Inactive'}</p>
+            <div class="tool-actions">
+              <button class="primary" onclick="window.open('${escapeHtml(tool.toolUrl)}','_blank','noopener')">Open</button>
+              ${isRoleAtLeast(appState.session.user.role, 'ADMIN') ? `<button class="ghost" data-tool="${tool.id}" onclick="editTool('${tool.id}')">Edit</button>
+              <button class="danger" data-tool="${tool.id}" onclick="toggleToolActive('${tool.id}', ${tool.isActive})">${tool.isActive ? 'Deactivate' : 'Activate'}</button>` : ''}
+            </div>
+          </div>
+        `).join('');
+      }
+
+      function handleToolSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const payload = Object.fromEntries(new FormData(form).entries());
+        payload.sortOrder = payload.sortOrder ? Number(payload.sortOrder) : '';
+        payload.isActive = form.isActive.checked;
+        const handler = payload.id ? 'updateTool' : 'createTool';
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast('Tool saved.');
+              form.reset();
+              form.isActive.checked = true;
+              document.getElementById('toolCancel').classList.add('hidden');
+              loadTools();
+            } else {
+              handleError((res && res.message) || 'Unable to save tool');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          [handler](payload);
+      }
+
+      function resetToolForm() {
+        const form = document.getElementById('toolForm');
+        form.reset();
+        form.id.value = '';
+        form.isActive.checked = true;
+        document.getElementById('toolCancel').classList.add('hidden');
+      }
+
+      window.editTool = function (toolId) {
+        const tool = appState.tools.find(t => t.id === toolId);
+        if (!tool) return;
+        const form = document.getElementById('toolForm');
+        form.id.value = tool.id;
+        form.iconUrl.value = tool.iconUrl || '';
+        form.name.value = tool.name || '';
+        form.toolUrl.value = tool.toolUrl || '';
+        form.sortOrder.value = tool.sortOrder || '';
+        form.isActive.checked = !!tool.isActive;
+        document.getElementById('toolCancel').classList.remove('hidden');
+        showToast('Editing tool…');
+      };
+
+      window.toggleToolActive = function (toolId, isActive) {
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast(isActive ? 'Tool deactivated.' : 'Tool activated.');
+              loadTools();
+            } else {
+              handleError((res && res.message) || 'Unable to update tool');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .updateTool({ id: toolId, isActive: !isActive });
+      };
+
+      function populateSettings() {
+        const form = document.getElementById('settingsForm');
+        const user = appState.session.user;
+        form.notificationEmail.value = user.notificationEmail || user.email;
+        const prefs = user.preferences || { instant: true, daily: true, weekly: true };
+        form.instant.checked = prefs.instant !== false;
+        form.daily.checked = prefs.daily !== false;
+        form.weekly.checked = prefs.weekly !== false;
+      }
+
+      function handleSettingsSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const payload = {
+          notificationEmail: form.notificationEmail.value.trim(),
+          instant: form.instant.checked,
+          daily: form.daily.checked,
+          weekly: form.weekly.checked
+        };
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              appState.session.user = res.data;
+              showToast('Notification settings saved.');
+              populateSettings();
+            } else {
+              handleError((res && res.message) || 'Unable to save settings');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .saveEmailSettings(payload);
+      }
+
+      function sendTestEmail() {
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast('Test email sent.');
+            } else {
+              handleError((res && res.message) || 'Unable to send test email');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .sendTestEmail();
+      }
+
+      function markTutorialComplete() {
+        google.script.run
+          .withSuccessHandler(res => {
+            if (res && res.success) {
+              showToast('Tutorial marked complete.');
+              appState.session.user.tutorialSeen = true;
+            } else {
+              handleError((res && res.message) || 'Unable to update tutorial state');
+            }
+          })
+          .withFailureHandler(err => handleError(err.message))
+          .saveEmailSettings({ tutorialSeen: true });
+      }
+
+      function downloadTemplate() {
+        const headers = ['title', 'description', 'assignedTo', 'priority', 'status', 'dueDate', 'estimatedHours', 'tags', 'links'];
+        const csv = headers.join(',') + '\n';
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = 'auraflow_tasks_template.csv';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+
+      function loadUsersIfNeeded() {
+        if (!appState.loadedTabs.users) {
+          loadUsers();
+          appState.loadedTabs.users = true;
+        }
+      }
+      // Utility loaders for future lazy-loading hooks
+      function loadDashboardIfNeeded() { if (!appState.loadedTabs.dashboard) { loadDashboard(); appState.loadedTabs.dashboard = true; } }
+      function loadToolsIfNeeded() { if (!appState.loadedTabs.tools) { loadTools(); appState.loadedTabs.tools = true; } }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an initializeApp utility that provisions spreadsheet sheets and configures triggers with optional demo seeding
- implement createDemoData to seed sample users, tasks, time logs, and tools tied to mananvermabusiness@gmail.com

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd9846ee0c832f8f12f17820368293